### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -468,7 +468,7 @@ class SvgRenderer:
 
 
     def render(self, node, parent=None):
-        if parent == None:
+        if parent is None:
             parent = self.mainGroup
         name = node.nodeName
         if self.verbose:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:deeplook:svglib?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:deeplook:svglib?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)