### PR TITLE
Fixed bezier shorthand path operator in corner cases

### DIFF
--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -805,6 +805,7 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
         path = ArcPath()
         # Track subpaths needing to be closed later
         unclosed_subpath_pointers = []
+        lastop = ''
 
         for i in xrange(0, len(normPath), 2):
             op, nums = normPath[i:i+2]
@@ -848,7 +849,7 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
                 path.curveTo(*nums)
             elif op == 'S':
                 x2, y2, xn, yn = nums
-                if len(path.points) < 4:
+                if len(path.points) < 4 or lastop not in {'c', 'C', 's', 'S'}:
                     xp, yp, x0, y0 = path.points[-2:] * 2
                 else:
                     xp, yp, x0, y0 = path.points[-4:]
@@ -861,12 +862,12 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
                 x1, y1, x2, y2, xn, yn = nums
                 path.curveTo(xp + x1, yp + y1, xp + x2, yp + y2, xp + xn, yp + yn)
             elif op == 's':
-                if len(path.points) < 4:
+                x2, y2, xn, yn = nums
+                if len(path.points) < 4 or lastop not in {'c', 'C', 's', 'S'}:
                     xp, yp, x0, y0 = path.points[-2:] * 2
                 else:
                     xp, yp, x0, y0 = path.points[-4:]
                 xi, yi = x0 + (x0 - xp), y0 + (y0 - yp)
-                x2, y2, xn, yn = nums
                 path.curveTo(xi, yi, x0 + x2, y0 + y2, x0 + xn, y0 + yn)
 
             # quadratic bezier, absolute
@@ -939,6 +940,7 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
 
             else:
                 logger.debug("Suspicious path operator: %s" % op)
+            lastop = op
 
         gr = Group()
         self.applyStyleOnShape(path, node)

--- a/tests/NOTES.rst
+++ b/tests/NOTES.rst
@@ -16,28 +16,23 @@ wikipedia/flags
 Issues here are often very small and related to paths or fillings.
 
 - Andorra.svg
-- Argentina.svg
 - Australia_(converted).svg (clipPath support)
 - Belize.svg (gradient support)
-- Bolivia_(state).svg
 - Ecuador.svg (gradient support)
 - Egypt.svg
-- El_salvador.svg
 - Georgia.svg (clipPath support)
-- Guatemala.svg
+- Guatemala.svg (gradient support)
 - Haiti.svg
-- Lesotho.svg
-- Mexico.svg
+- Mexico.svg (gradient support)
 - Moldova.svg
 - New_zealand.svg (clipPath support)
-- Nicaragua.svg
-- Pakistan.svg
-- Slovakia.svg
-- Slovenia.svg
+- Nicaragua.svg (clipPath/gradient support)
+- Pakistan.svg (FILL_NON_ZERO on polygon?)
+- Slovenia.svg (svg inside svg)
 - South_africa.svg (clipPath support)
-- South_sudan.svg
+- South_sudan.svg (FILL_NON_ZERO on polygon?)
 - Swaziland.svg
-- Tajikistan.svg
+- Tajikistan.svg (FILL_NON_ZERO on polygon?)
 - The_cook_islands.svg (clipPath support)
 - The_dominican_republic.svg
 - The_republic_of_china.svg


### PR DESCRIPTION
From the specs for 's'/'S' path operator: If there is no previous command
or if the previous command was not an C, c, S or s, assume the first control
point is coincident with the current point.