### PR TITLE
Set default path fill mode to non-zero in RL monkeypatch

### DIFF
--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -1221,6 +1221,8 @@ def monkeypatch_reportlab():
         current = self._fillMode
         if hasattr(path, 'fillMode'):
             self._fillMode = path.fillMode
+        else:
+            self._fillMode = FILL_NON_ZERO
         original_drawPath(self, path, **kwargs)
         self._fillMode = current
     Canvas.drawPath = patchedDrawPath

--- a/tests/NOTES.rst
+++ b/tests/NOTES.rst
@@ -18,22 +18,18 @@ Issues here are often very small and related to paths or fillings.
 - Andorra.svg
 - Belize.svg (gradient support)
 - Ecuador.svg (gradient support)
-- Egypt.svg
+- Egypt.svg (fill attribute on group not reused by <use> node)
 - Guatemala.svg (gradient support)
 - Haiti.svg
 - Mexico.svg (gradient support)
 - Moldova.svg
 - Nicaragua.svg (gradient support)
-- Pakistan.svg (FILL_NON_ZERO on polygon?)
 - Slovenia.svg (svg inside svg)
-- South_sudan.svg (FILL_NON_ZERO on polygon?)
 - Swaziland.svg
-- Tajikistan.svg (FILL_NON_ZERO on polygon?)
 - The_dominican_republic.svg
 - The_republic_of_china.svg
 - The_vatican_city.svg
 - Transnistria_(state).svg
-- Turkey.svg (FILL_NON_ZERO on polygon?)
 - Turkmenistan.svg
 
 


### PR DESCRIPTION
Polygons for example are converted to paths by ReportLab, and need the
NON-ZERO fill mode.