### PR TITLE
Store definitions as nodes

### DIFF
--- a/tests/NOTES.rst
+++ b/tests/NOTES.rst
@@ -17,18 +17,13 @@ wikipedia/flags
 
 Issues here are often very small and related to paths or fillings.
 
-- Andorra.svg
 - Belize.svg (gradient support)
 - Ecuador.svg (gradient support)
-- Egypt.svg (fill attribute on group not reused by <use> node)
 - Guatemala.svg (gradient support)
-- Haiti.svg
 - Mexico.svg (gradient support)
 - Moldova.svg
 - Nicaragua.svg (gradient support)
 - Slovenia.svg (svg inside svg)
-- Swaziland.svg
-- The_dominican_republic.svg
 - The_republic_of_china.svg
 - The_vatican_city.svg
 - Transnistria_(state).svg

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -405,6 +405,7 @@ class TestUseNode(object):
               <rect x=".1" y=".1" width="99.8" height="29.8"
                     fill="none" stroke="blue" stroke-width=".2" />
               <use x="20" y="10" xlink:href="#MyRect" />
+              <use x="30" y="20" xlink:href="#MyRect" fill="#f00" />
             </svg>
         ''')))
         main_group = drawing.contents[0]
@@ -412,6 +413,10 @@ class TestUseNode(object):
         assert isinstance(main_group.contents[0], Rect)
         # Second Rect defined by the use node (inside a Group)
         assert isinstance(main_group.contents[1].contents[0], Rect)
+        assert main_group.contents[1].contents[0].fillColor == colors.black  # default
+        # Attributes on the use node are applied to the referenced content
+        assert isinstance(main_group.contents[2].contents[0], Rect)
+        assert main_group.contents[2].contents[0].fillColor == colors.red
 
     def test_transform_inherited_by_use(self):
         drawing = svglib.svg2rlg(io.StringIO(textwrap.dedent(u'''\


### PR DESCRIPTION
Nodes have to be re-rendered at each <use> as the parent hierarchy can
impact the inherited attributes.