### PR TITLE
Also unset strokeColor for fake fill-only shapes

### DIFF
--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -191,6 +191,8 @@ class NoStrokeArcPath(ArcPath):
         props = ArcPath.getProperties(self, *args, **kwargs)
         if 'strokeWidth' in props:
             props['strokeWidth'] = 0
+        if 'strokeColor' in props:
+            props['strokeColor'] = None
         return props
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -490,6 +490,7 @@ class TestUseNode(object):
         ''')))
         use_group = drawing.contents[0].contents[0].contents[0]
         assert use_group.contents[0].getProperties()['strokeWidth'] == 0
+        assert use_group.contents[0].getProperties()['strokeColor'] is None
 
 
 class TestViewBox(object):


### PR DESCRIPTION
Even when strokeWidth is 0, some rendering backends show a light
stroke line when strokeColor is not None.