### PR TITLE
add colorConverter option

### DIFF
--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -201,10 +201,10 @@ class Svg2RlgAttributeConverter(AttributeConverter):
     "A concrete SVG to RLG attribute converter."
 
     def __init__(self,color_converter=None):
-        self.color_converter = color_converter or self.identitycolor_converter
+        self.color_converter = color_converter or self.identity_color_converter
 
     @staticmethod
-    def identitycolor_converter(c):
+    def identity_color_converter(c):
         return c
 
     def convertLength(self, svgAttr, percentOf=100):

--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -200,6 +200,13 @@ class AttributeConverter:
 class Svg2RlgAttributeConverter(AttributeConverter):
     "A concrete SVG to RLG attribute converter."
 
+    def __init__(self,colorConverter=None):
+        self.colorConverter = colorConverter or self.identityColorConverter
+
+    @staticmethod
+    def identityColorConverter(c):
+        return c
+
     def convertLength(self, svgAttr, percentOf=100):
         "Convert length to points."
 
@@ -266,19 +273,19 @@ class Svg2RlgAttributeConverter(AttributeConverter):
         elif text == "currentColor":
             return "currentColor"
         elif len(text) == 7 and text[0] == '#':
-            return colors.HexColor(text)
+            return self.colorConverter(colors.HexColor(text))
         elif len(text) == 4 and text[0] == '#':
-            return colors.HexColor('#' + 2*text[1] + 2*text[2] + 2*text[3])
+            return self.colorConverter(colors.HexColor('#' + 2*text[1] + 2*text[2] + 2*text[3]))
         elif text.startswith('rgb') and '%' not in text:
             t = text[3:].strip('()')
             tup = [h[2:] for h in [hex(int(num)) for num in t.split(',')]]
             tup = [(2 - len(h)) * '0' + h for h in tup]
             col = "#%s%s%s" % tuple(tup)
-            return colors.HexColor(col)
+            return self.colorConverter(colors.HexColor(col))
         elif text.startswith('rgb') and '%' in text:
             t = text[3:].replace('%', '').strip('()')
             tup = (int(val)/100.0 for val in t.split(','))
-            return colors.Color(*tup)
+            return self.colorConverter(colors.Color(*tup))
 
         logger.warn("Can't handle color: %s" % text)
 
@@ -350,9 +357,9 @@ class SvgRenderer:
     transforming it into a ReportLab Drawing instance.
     """
 
-    def __init__(self, path=None):
-        self.attrConverter = Svg2RlgAttributeConverter()
-        self.shape_converter = Svg2RlgShapeConverter(path)
+    def __init__(self, path=None,colorConverter=None):
+        self.attrConverter = Svg2RlgAttributeConverter(colorConverter=colorConverter)
+        self.shape_converter = Svg2RlgShapeConverter(path,self.attrConverter)
         self.handled_shapes = self.shape_converter.get_handled_shapes()
         self.definitions = {}
         self.waiting_use_nodes = defaultdict(list)
@@ -535,10 +542,8 @@ class SvgShapeConverter:
     Each of these methods should return a shape object appropriate
     for the target format.
     """
-    AttributeConverterClass = AttributeConverter
-
-    def __init__(self, path):
-        self.attrConverter = self.AttributeConverterClass()
+    def __init__(self, path, attrConverter):
+        self.attrConverter = attrConverter
         self.svg_source_file = path
         self.preserve_space = False
 
@@ -552,8 +557,6 @@ class SvgShapeConverter:
 
 class Svg2RlgShapeConverter(SvgShapeConverter):
     """Converter from SVG shapes to RLG (ReportLab Graphics) shapes."""
-
-    AttributeConverterClass = Svg2RlgAttributeConverter
 
     def convertShape(self, name, node, clipping=None):
         method_name = "convert%s" % name.capitalize()
@@ -1006,7 +1009,7 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
             shape.fillColor.alpha = shape.fillOpacity
 
 
-def svg2rlg(path):
+def svg2rlg(path,**kwds):
     "Convert an SVG file to an RLG Drawing object."
 
     # unzip .svgz file into .svg
@@ -1027,7 +1030,7 @@ def svg2rlg(path):
         return
 
     # convert to a RLG drawing
-    svgRenderer = SvgRenderer(path)
+    svgRenderer = SvgRenderer(path,**kwds)
     drawing = svgRenderer.render(svg)
 
     # remove unzipped .svgz file (.svg)

--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -200,11 +200,11 @@ class AttributeConverter:
 class Svg2RlgAttributeConverter(AttributeConverter):
     "A concrete SVG to RLG attribute converter."
 
-    def __init__(self,colorConverter=None):
-        self.colorConverter = colorConverter or self.identityColorConverter
+    def __init__(self,color_converter=None):
+        self.color_converter = color_converter or self.identitycolor_converter
 
     @staticmethod
-    def identityColorConverter(c):
+    def identitycolor_converter(c):
         return c
 
     def convertLength(self, svgAttr, percentOf=100):
@@ -273,19 +273,19 @@ class Svg2RlgAttributeConverter(AttributeConverter):
         elif text == "currentColor":
             return "currentColor"
         elif len(text) == 7 and text[0] == '#':
-            return self.colorConverter(colors.HexColor(text))
+            return self.color_converter(colors.HexColor(text))
         elif len(text) == 4 and text[0] == '#':
-            return self.colorConverter(colors.HexColor('#' + 2*text[1] + 2*text[2] + 2*text[3]))
+            return self.color_converter(colors.HexColor('#' + 2*text[1] + 2*text[2] + 2*text[3]))
         elif text.startswith('rgb') and '%' not in text:
             t = text[3:].strip('()')
             tup = [h[2:] for h in [hex(int(num)) for num in t.split(',')]]
             tup = [(2 - len(h)) * '0' + h for h in tup]
             col = "#%s%s%s" % tuple(tup)
-            return self.colorConverter(colors.HexColor(col))
+            return self.color_converter(colors.HexColor(col))
         elif text.startswith('rgb') and '%' in text:
             t = text[3:].replace('%', '').strip('()')
             tup = (int(val)/100.0 for val in t.split(','))
-            return self.colorConverter(colors.Color(*tup))
+            return self.color_converter(colors.Color(*tup))
 
         logger.warn("Can't handle color: %s" % text)
 
@@ -357,8 +357,8 @@ class SvgRenderer:
     transforming it into a ReportLab Drawing instance.
     """
 
-    def __init__(self, path=None,colorConverter=None):
-        self.attrConverter = Svg2RlgAttributeConverter(colorConverter=colorConverter)
+    def __init__(self, path=None,color_converter=None):
+        self.attrConverter = Svg2RlgAttributeConverter(color_converter=color_converter)
         self.shape_converter = Svg2RlgShapeConverter(path,self.attrConverter)
         self.handled_shapes = self.shape_converter.get_handled_shapes()
         self.definitions = {}
@@ -542,7 +542,7 @@ class SvgShapeConverter:
     Each of these methods should return a shape object appropriate
     for the target format.
     """
-    def __init__(self, path, attrConverter):
+    def __init__(self, path, attrConverter=None):
         self.attrConverter = attrConverter
         self.svg_source_file = path
         self.preserve_space = False
@@ -1009,7 +1009,7 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
             shape.fillColor.alpha = shape.fillOpacity
 
 
-def svg2rlg(path,**kwds):
+def svg2rlg(path,**kwargs):
     "Convert an SVG file to an RLG Drawing object."
 
     # unzip .svgz file into .svg
@@ -1030,7 +1030,7 @@ def svg2rlg(path,**kwds):
         return
 
     # convert to a RLG drawing
-    svgRenderer = SvgRenderer(path,**kwds)
+    svgRenderer = SvgRenderer(path,**kwargs)
     drawing = svgRenderer.render(svg)
 
     # remove unzipped .svgz file (.svg)

--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -269,7 +269,7 @@ class Svg2RlgAttributeConverter(AttributeConverter):
             return None
 
         if text in predefined.split():
-            return getattr(colors, text)
+            return self.color_converter(getattr(colors, text))
         elif text == "currentColor":
             return "currentColor"
         elif len(text) == 7 and text[0] == '#':
@@ -543,7 +543,7 @@ class SvgShapeConverter:
     for the target format.
     """
     def __init__(self, path, attrConverter=None):
-        self.attrConverter = attrConverter
+        self.attrConverter = attrConverter or Svg2RlgAttributeConverter()
         self.svg_source_file = path
         self.preserve_space = False
 

--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -1009,7 +1009,7 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
             shape.fillColor.alpha = shape.fillOpacity
 
 
-def svg2rlg(path,**kwargs):
+def svg2rlg(path, **kwargs):
     "Convert an SVG file to an RLG Drawing object."
 
     # unzip .svgz file into .svg

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -149,6 +149,9 @@ class TestPaths(object):
         group = converter.convertPath(node)
         assert group is None
 
+def force_cmyk(rgb):
+    c, m, y, k = colors.rgb2cmyk(rgb.red,rgb.green,rgb.blue)
+    return colors.CMYKColor(c,m,y,k,alpha=rgb.alpha)
 
 class TestColorAttrConverter(object):
     "Testing color attribute conversion."
@@ -164,6 +167,22 @@ class TestColorAttrConverter(object):
             ("rgb(255, 0, 0)", colors.red),
         )
         ac = svglib.Svg2RlgAttributeConverter()
+        failed = _testit(ac.convertColor, mapping)
+        assert len(failed) == 0
+
+    def test_1(self):
+        "Test color attribute conversion to CMYK"
+
+        mapping = (
+            ("red", force_cmyk(colors.red)),
+            ("#ff0000", force_cmyk(colors.red)),
+            ("#f00", force_cmyk(colors.red)),
+            ("rgb(100%,0%,0%)", force_cmyk(colors.red)),
+            ("rgb(255, 0, 0)", force_cmyk(colors.red)),
+            ("rgb(0,255, 0)", force_cmyk(colors.Color(0,1,0))),
+            ("rgb(0, 0, 255)", force_cmyk(colors.Color(0,0,1))),
+        )
+        ac = svglib.Svg2RlgAttributeConverter(color_converter=force_cmyk)
         failed = _testit(ac.convertColor, mapping)
         assert len(failed) == 0
 


### PR DESCRIPTION
Hi, when using svglib to create RL drawings for use with existing document flows it may be necessary to use specific color schemes. This pull request does 2 things:

1) use a single Svg2RlgAttributeConverter instance by passing the renderer instance to the  Svg2RlgShapeConverter instance.

2) Add optional colorConverter argument to the Svg2RlgAttributeConverter class to allow conversion to take place in convertColor.

With these in place I can use svg2rl to make CMYK etc etc drawings.

--HG--
branch : colorConverter