### PR TITLE
Support <rect> as a clipping source in addition to paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ docs/_build
 env/
 .workon
 dist/
+.idea

--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -434,11 +434,26 @@ class SvgRenderer:
         Return the clipping Path object referenced by the node 'clip-path'
         attribute, if any.
         """
+
         def get_path_from_node(node):
             for child in node.getchildren():
                 if node_name(child) == 'path':
                     group = self.shape_converter.convertShape('path', NodeTracker(child))
                     return group.contents[-1]
+                elif node_name(child) == 'rect':
+                    # it is possible to use a rect as a clipping path in an svg, so we
+                    # need to convert it to a path for rlg.  if there is a better way...
+                    rect = self.shape_converter.convertRect(NodeTracker(child))
+                    x1, y1, x2, y2 = rect.getBounds()
+                    p = ClippingPath()
+                    p.moveTo(x1, y1)
+                    p.lineTo(x2, y1)
+                    p.lineTo(x2, y2)
+                    p.lineTo(x1, y2)
+                    p.closePath()
+                    # copy the styles from the rect to the clipping path
+                    self.shape_converter.applyStyleOnShape(p, child)
+                    return p
                 else:
                     return get_path_from_node(child)
 


### PR DESCRIPTION
I guess its just easier to show than to say, so see below.  We have tons of constructs like this in our SVGs (I didn't write them, I don't know if its good or bad).  Basically, they use rectangles as the source for clipping, and they are referenced by donzens of individual paths.  The current implementation only supports `<path>` data, so this was giving some disturbing visuals :D 

```xml
<defs>
    <rect id="my-clipping-rect" x="88.155" y="163" width="419.69" height="20.68"/>
</defs>
<clipPath id="my-clip-path">
    <use xlink:href="#my-clipping-rect"  overflow="visible"/>
</clipPath>
<path clip-path="url(#my-clip-path)" d="M99.023,176.012c-0.19,0-0.654-...."/>
```

This patch adds simple support for parsing out that <rect> and turning it into a path.  I'm new to reportlab so I'm not sure i'm doing it exactly correct.  Please review! 

I considered writing out the path as a path string and parsing that, or `points=` and `operations=` but they felt just as long and not as clear.  If there is a better, proper, way then I'd love to know.

Thanks for all your updates to svglib!  They made the svg we have render 99% properly, a huge step up from the previous version that I forked before.