### PR TITLE
Change license classifier from GPL to LGPL3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'Environment :: Console',
         'Intended Audience :: End Users/Desktop',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU General Public License (GPL)',
+        'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: POSIX',
         'Natural Language :: English',


### PR DESCRIPTION
I noticed that although the license is LGPL the trove classifier is still GPL. This updates the classifier to the correct string for LGPL-licensed packages.