### PR TITLE
Run LGTM on Python 3 and add some flake8 tests

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,12 @@
+extraction:
+  python:
+    python_setup:
+      version: 3
+    after_prepare:
+      - python3 -m pip install --upgrade --user flake8
+    before_index:
+      - python3 -m flake8 --version  # flake8 3.6.0 on CPython 3.6.5 on Linux
+      # stop the build if there are Python syntax errors or undefined names
+      - python3 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+      # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+      - python3 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics


### PR DESCRIPTION
LGTM defaults to legacy Python so this PR shifts it up to Python 3 and also add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree