### PR TITLE
Fixing deprecation warning for raw string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .coverage
-.idea
 MANIFEST
 coverage.xml
 nosetests.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .coverage
+.idea
 MANIFEST
 coverage.xml
 nosetests.xml

--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -69,7 +69,7 @@ logger = logging.getLogger(__name__)
 
 Box = namedtuple('Box', ['x', 'y', 'width', 'height'])
 
-split_whitespace = re.compile('[^ \t\r\n\f]+').findall
+split_whitespace = re.compile(r'[^ \t\r\n\f]+').findall
 
 
 def find_font(font_name):

--- a/svglib/utils.py
+++ b/svglib/utils.py
@@ -16,7 +16,7 @@ def split_floats(op, min_num, value):
     Example: with op='m' and value='10,20 30,40,' the returned value will be
              ['m', [10.0, 20.0], 'l', [30.0, 40.0]]
     """
-    floats = [float(seq) for seq in re.findall('(-?\d*\.?\d*(?:e[+-]\d+)?)', value) if seq]
+    floats = [float(seq) for seq in re.findall(r'(-?\d*\.?\d*(?:e[+-]\d+)?)', value) if seq]
     res = []
     for i in range(0, len(floats), min_num):
         if i > 0 and op in {'m', 'M'}:


### PR DESCRIPTION
test of my application code shows me that:
/python_modules/svglib/svglib/utils.py:19
  /python_modules/svglib/svglib/utils.py:19: DeprecationWarning: invalid escape sequence \d
    floats = [float(seq) for seq in re.findall('(-?\d*\.?\d*(?:e[+-]\d+)?)', value) if seq]

Fixing that.