### PR TITLE
Fix bug where temporary files are not closed

### DIFF
--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -643,9 +643,11 @@ class SvgRenderer:
         if match:
             img_format = match.groups()[0]
             image_data = base64.decodestring(xlink_href[(match.span(0)[1] + 1):].encode('ascii'))
-            _, path = tempfile.mkstemp(suffix='.%s' % img_format)
+            file_indicator, path = tempfile.mkstemp(suffix='.%s' % img_format)
             with open(path, 'wb') as fh:
                 fh.write(image_data)
+            # Close temporary file (as opened by tempfile.mkstemp)
+            os.close(file_indicator)
             # this needs to be removed later, not here...
             # if exists(path): os.remove(path)
             return path


### PR DESCRIPTION
I noticed that while mass-converting a bunch of SVGs to PNGs (400+) this script was opening hundreds of temporary files, not closing them, and crashing with an OSerror of "too many files open." The source stems from the  `tempfile.mkstemp` actually opening the temporary file it creates (it's a separate open from the `open(path, 'wb')`, and not closing it (guess garbage collection doesn't grab it properly?) This fix resolves the issue for me.