### PR TITLE
Updated license link in the svg2pdf script

### DIFF
--- a/scripts/svg2pdf
+++ b/scripts/svg2pdf
@@ -90,7 +90,7 @@ def _main():
             https://github.com/deeplook/svglib
 
         Copyleft by {author}, 2008-{copyleft_year} ({license}):
-            http://www.gnu.org/copyleft/gpl.html'''.format(**args))
+            https://www.gnu.org/licenses/lgpl-3.0.html'''.format(**args))
     p = argparse.ArgumentParser(
         description=desc,
         epilog=epilog,


### PR DESCRIPTION
Hi, this is a very nice job. 

I found that, despite claimed as LGPL3, the link to the license description is to GPL3. This may create problems if using this software under the LGPL3 licensing. I modified the link, assuming this was an overlooking. I found that even in the `PGK-INFO` and `svglib.egg-info/PKG-INFO` files there is the same problem but I suppose those are automatically generated from the file I edited. 

Hope you consider to issue a new version ASAP (even with only this small modification) since this is really important from a legal point of view. 

Thank you