### PR TITLE
Apply the transformation matrix to the group transform

### DIFF
--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -33,6 +33,7 @@ from reportlab.graphics.shapes import (
     _CLOSEPATH, Circle, Drawing, Ellipse, Group, Image, Line, Path, PolyLine,
     Polygon, Rect, SolidShape, String,
 )
+from reportlab.graphics.transform import mmult
 from reportlab.lib import colors
 from reportlab.lib.units import pica, toLength
 from reportlab.lib.utils import haveImages
@@ -1334,7 +1335,10 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
             elif op == "skewY":
                 group.skew(0, values)
             elif op == "matrix":
-                group.transform = values
+                if len(values) == 6:
+                    group.transform = mmult(group.transform, values)
+                else:
+                    group.transform = values
             else:
                 logger.debug("Ignoring transform: %s %s", op, values)
 


### PR DESCRIPTION
Apply the transformation matrix to the group transform by matrix multiplication.

If the "values" is directly assigned to the group transform, then the
the original transformation of the group is lost.

Use the old code if the length of the "values" is not 6. This is somewhat
an undefined state.