### PR TITLE
Fixes #313 - Revert scripts to console_scripts move during setup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@
 ChangeLog
 =========
 
+1.2.1 (2022-01-27)
+------------------
+
+- Revert to scripts usage instead of console_scripts during setup (#313).
+
 1.2.0 (2022-01-20)
 ------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,10 +50,8 @@ packages =
     svglib
 package_dir =
     svglib = svglib
-
-[options.entry_points]
-console_scripts =
-    svg2pdf = svglib.svg2pdf:_main
+scripts =
+    scripts/svg2pdf
 
 [options.data_files]
 share/man/man1 = svg2pdf.1


### PR DESCRIPTION
Partially revert 15da634750d3. Using console_scripts instead of scripts also
involves changing the code/location of scripts/svg2pdf.
This may be done at a later point.