### PR TITLE
Guard against empty style tags

### DIFF
--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -868,7 +868,7 @@ class SvgRenderer:
         return gr
 
     def renderStyle(self, node):
-        self.attrConverter.css_rules = CSSMatcher(node.text)
+        self.attrConverter.css_rules = CSSMatcher(node.text or "")
 
     def renderSymbol(self, node):
         return self.renderG(node, display=0)

--- a/tests/samples/others/empty_style.svg
+++ b/tests/samples/others/empty_style.svg
@@ -1,0 +1,1 @@
+<svg width="10" height="10" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><style></style></svg>

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -443,3 +443,7 @@ class TestOtherFiles:
         path = join(TEST_ROOT, "samples", "others", "em_unit.svg")
         drawing = svglib.svg2rlg(path)
         assert drawing.contents[0].transform[5] == svglib.DEFAULT_FONT_SIZE
+
+    def test_empty_style(self):
+        path = join(TEST_ROOT, "samples", "others", "empty_style.svg")
+        svglib.svg2rlg(path)


### PR DESCRIPTION
An SVG with emtpy style tag like `<style></style>` breaks parsing because `node.text` is `None` and  `CSSMatcher`  doesn't like a `None` argument.

This PR fixes this by passing in an empty string if `node.text` is Falsey. Test included.