### PR TITLE
Allow multiple style nodes

### DIFF
--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -127,12 +127,15 @@ class ClippingPath(Path):
 
 
 class CSSMatcher(cssselect2.Matcher):
-    def __init__(self, style_content):
+    def __init__(self):
         super().__init__()
-        self.rules = tinycss2.parse_stylesheet(
+
+    def add_styles(self, style_content):
+        rules = tinycss2.parse_stylesheet(
             style_content, skip_comments=True, skip_whitespace=True
         )
-        for rule in self.rules:
+
+        for rule in rules:
             if not rule.prelude:
                 continue
             selectors = cssselect2.compile_selector_list(rule.prelude)
@@ -542,6 +545,7 @@ class SvgRenderer:
         self.definitions = {}
         self.waiting_use_nodes = defaultdict(list)
         self._external_svgs = {}
+        self.attrConverter.css_rules = CSSMatcher()
 
     def render(self, svg_node):
         node = NodeTracker(svg_node)
@@ -868,7 +872,7 @@ class SvgRenderer:
         return gr
 
     def renderStyle(self, node):
-        self.attrConverter.css_rules = CSSMatcher(node.text or "")
+        self.attrConverter.css_rules.add_styles(node.text or "")
 
     def renderSymbol(self, node):
         return self.renderG(node, display=0)

--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -127,9 +127,6 @@ class ClippingPath(Path):
 
 
 class CSSMatcher(cssselect2.Matcher):
-    def __init__(self):
-        super().__init__()
-
     def add_styles(self, style_content):
         rules = tinycss2.parse_stylesheet(
             style_content, skip_comments=True, skip_whitespace=True

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -527,6 +527,28 @@ class TestStyleSheets:
         assert main_group.contents[0].contents[1].contents[0].fillColor == colors.black
         assert main_group.contents[0].contents[1].contents[0].strokeWidth == 1.5
 
+    def test_css_stylesheet_multiple_style_tags(self):
+        drawing = svglib.svg2rlg(io.StringIO(textwrap.dedent('''\
+            <?xml version="1.0"?>
+            <svg width="777" height="267" xml:space="preserve">
+              <defs>
+                <style type="text/css">
+                #p1 { fill:rgb(255,0,0) }
+                </style>
+                <style type="text/css">
+                #p2 { fill:rgb(0,0,0); }
+                </style>
+              </defs>
+              <g>
+                <path id="p1" d="M 0,-100 V 0 H 50"/>
+                <path id="p2" d="M 0,100 V 0 H 50"/>
+              </g>
+            </svg>
+        ''')))
+        main_group = drawing.contents[0]
+        assert main_group.contents[0].contents[0].contents[0].fillColor == colors.red
+        assert main_group.contents[0].contents[1].contents[0].fillColor == colors.black
+
 
 class TestGroupNode:
     def test_svg_groups_have_svgid(self):


### PR DESCRIPTION
I am dealing with SVGs generated by a tool that puts a style tag for each class into defs. At the moment the result of using svg2rlg is that only the last style element is used.

This PR changes the behavior of renderStyle to append additional rules to the CSSMatcher that was created during initialization of SvgRenderer.