### PR TITLE
"ex" and "ch" must be assumed as em/2

### DIFF
--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -325,10 +325,14 @@ class Svg2RlgAttributeConverter(AttributeConverter):
             return float(text[:-2]) * em_base
         elif text.endswith("px"):
             return float(text[:-2])
-
-        if "ex" in text:
-            logger.warning("Ignoring unit ex")
-            text = text.replace("ex", '')
+        elif text.endswith("ex"):
+            # The x-height of the text must be assumed to be 0.5em tall when the
+            # text cannot be measured.
+            return float(text[:-2]) * em_base / 2
+        elif text.endswith("ch"):
+            # The advance measure of the "0" glyph must be assumed to be 0.5em
+            # wide when the text cannot be measured.
+            return float(text[:-2]) * em_base / 2
 
         text = text.strip()
         length = toLength(text)  # this does the default measurements such as mm and cm

--- a/tests/samples/others/em_unit.svg
+++ b/tests/samples/others/em_unit.svg
@@ -1,1 +1,0 @@
-<svg width="1em" height="1em" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"></svg>

--- a/tests/samples/others/units.svg
+++ b/tests/samples/others/units.svg
@@ -1,0 +1,10 @@
+<svg width="100px" height="100px" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <line x1="1px" y1="10px" x2="2px" y2="10px" stroke="black" />
+  <line x1="1pt" y1="20px" x2="2pt" y2="20px" stroke="black" />
+  <line x1="1mm" y1="30px" x2="2mm" y2="30px" stroke="black" />
+  <line x1="1ex" y1="40px" x2="2ex" y2="40px" stroke="black" />
+  <line x1="1ch" y1="50px" x2="2ch" y2="50px" stroke="black" />
+  <line x1="1em" y1="60px" x2="2em" y2="60px" stroke="black" />
+  <line x1="1pc" y1="70px" x2="2pc" y2="70px" stroke="black" />
+  <line x1="1cm" y1="80px" x2="2cm" y2="80px" stroke="black" />
+</svg>

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -439,10 +439,17 @@ class TestOtherFiles:
         assert isinstance(img_group.contents[1].contents[0], Rect)
         assert img_group.contents[1].transform, (1, 0, 0, 1, 100.0, 200.0)
 
-    def test_em_unit_svg(self):
-        path = join(TEST_ROOT, "samples", "others", "em_unit.svg")
+    def test_units_svg(self):
+        path = join(TEST_ROOT, "samples", "others", "units.svg")
         drawing = svglib.svg2rlg(path)
-        assert drawing.contents[0].transform[5] == svglib.DEFAULT_FONT_SIZE
+        unit_widths = [line.getBounds()[0] for line in drawing.contents[0].contents]
+        assert unit_widths == sorted(unit_widths)
+        unit_names = ["px", "pt", "mm", "ex", "ch", "em", "pc", "cm"]
+        lengths_by_name = dict(zip(unit_names, unit_widths))
+        assert lengths_by_name["px"] == 1 # 1px == 1px
+        assert lengths_by_name["em"] == svglib.DEFAULT_FONT_SIZE # 1 em == font size
+        assert lengths_by_name["ex"] == lengths_by_name["em"] / 2
+        assert lengths_by_name["ch"] == lengths_by_name["ex"]
 
     def test_empty_style(self):
         path = join(TEST_ROOT, "samples", "others", "empty_style.svg")


### PR DESCRIPTION
My interest in this is specifically support for `ch`, as it's the only way to get SVGs to be able to get lines aligned with text well.

W3 offers guidance on what to do when you can't inspect the text to determine the x-height (`ex`) or the advance measure of a `0` glyph (`ch`).
* In the cases where it is impossible or impractical to determine the x-height, a value of 0.5em must be assumed.
* In the cases where it is impossible or impractical to determine the measure of the “0” glyph, it must be assumed to be 0.5em wide by 1em tall.

There's precedent in both [CairoSVG](https://github.com/Kozea/CairoSVG/blob/49c53b3a1d59d8ba1236095505e6ffb70f9ddfcb/cairosvg/helpers.py#L379) and [ImageMagick](https://github.com/ImageMagick/ImageMagick/blob/b42d5cbea9bb289130094d6299ff4897b75ab37b/coders/svg.c#L725) which have already adopted `em / 2.0` as their way to interpret `ex`, so with this change, I'm only suggesting that svglib do the same.

Neither currently support `ch`, but it's good to follow W3's advice.

---

Here's the motivating case of an SVG I made:

![ophistory_all](https://user-images.githubusercontent.com/335281/184275362-932faf91-470f-469e-9b97-18dcad5d4f24.svg)


This probably renders fine, as you're looking at it from a webbrowser, which understands how to render `ch` correctly.

Currently, processing this SVG into a png with svglib+reportlab gives an error like:

```
Traceback (most recent call last):
  File "/home/miller/ws/ophistory/./ophistory.py", line 354, in <module>
    main(sys.argv)
  File "/home/miller/ws/ophistory/./ophistory.py", line 348, in main
    drawing = svg2rlg(f)
  File "/home/miller/.local/lib/python3.10/site-packages/svglib/svglib.py", line 1404, in svg2rlg
    drawing = svgRenderer.render(svg_root)
  File "/home/miller/.local/lib/python3.10/site-packages/svglib/svglib.py", line 502, in render
    view_box = self.get_box(node, default_box=True)
  File "/home/miller/.local/lib/python3.10/site-packages/svglib/svglib.py", line 768, in get_box
    width, height = map(self.attrConverter.convertLength, (width, height))
  File "/home/miller/.local/lib/python3.10/site-packages/svglib/svglib.py", line 334, in convertLength
    length = toLength(text)  # this does the default measurements such as mm and cm
  File "/home/miller/.local/lib/python3.10/site-packages/reportlab/lib/units.py", line 30, in toLength
    raise ValueError("Can't convert '%s' to length" % s)
ValueError: Can't convert '197ch' to length
```

With the change I have proposed, the diagram renders to a .png via svglib like:

![ophistory_all_svglib](https://user-images.githubusercontent.com/335281/184276073-a5f813a1-06ad-431e-bf4d-b3669f59f199.png)

And so even if assuming `0.5em` is slightly inaccurate, is such an incredible improvement that I think it justifies using `ex` as an approximation for `ch`.
