### PR TITLE
Fix quadratic to cubic path conversion, add test

### DIFF
--- a/svglib/svglib.py
+++ b/svglib/svglib.py
@@ -1169,10 +1169,10 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
             elif op == 'Q':
                 x0, y0 = points[-2:]
                 x1, y1, xn, yn = nums
+                last_quadratic_cp = (x1, y1)
                 (x0, y0), (x1, y1), (x2, y2), (xn, yn) = \
                     convert_quadratic_to_cubic_path((x0, y0), (x1, y1), (xn, yn))
                 path.curveTo(x1, y1, x2, y2, xn, yn)
-                last_quadratic_cp = (x1, y1)
             elif op == 'T':
                 if last_quadratic_cp is not None:
                     xp, yp = last_quadratic_cp
@@ -1180,21 +1180,21 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
                     xp, yp = points[-2:]
                 x0, y0 = points[-2:]
                 xi, yi = x0 + (x0 - xp), y0 + (y0 - yp)
+                last_quadratic_cp = (xi, yi)
                 xn, yn = nums
                 (x0, y0), (x1, y1), (x2, y2), (xn, yn) = \
                     convert_quadratic_to_cubic_path((x0, y0), (xi, yi), (xn, yn))
                 path.curveTo(x1, y1, x2, y2, xn, yn)
-                last_quadratic_cp = (xi, yi)
 
             # quadratic bezier, relative
             elif op == 'q':
                 x0, y0 = points[-2:]
                 x1, y1, xn, yn = nums
                 x1, y1, xn, yn = x0 + x1, y0 + y1, x0 + xn, y0 + yn
+                last_quadratic_cp = (x1, y1)
                 (x0, y0), (x1, y1), (x2, y2), (xn, yn) = \
                     convert_quadratic_to_cubic_path((x0, y0), (x1, y1), (xn, yn))
                 path.curveTo(x1, y1, x2, y2, xn, yn)
-                last_quadratic_cp = (x1, y1)
             elif op == 't':
                 if last_quadratic_cp is not None:
                     xp, yp = last_quadratic_cp
@@ -1204,10 +1204,10 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
                 xn, yn = nums
                 xn, yn = x0 + xn, y0 + yn
                 xi, yi = x0 + (x0 - xp), y0 + (y0 - yp)
+                last_quadratic_cp = (xi, yi)
                 (x0, y0), (x1, y1), (x2, y2), (xn, yn) = \
                     convert_quadratic_to_cubic_path((x0, y0), (xi, yi), (xn, yn))
                 path.curveTo(x1, y1, x2, y2, xn, yn)
-                last_quadratic_cp = (xi, yi)
 
             # elliptical arc
             elif op in ('A', 'a'):

--- a/tests/samples/others/quadratic_path.svg
+++ b/tests/samples/others/quadratic_path.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+    <path d="M0 5
+    Q 0 10 5 10
+    t 5 -5
+    q 0 -5 -5 -5
+    T 0 5
+    Z"/>
+</svg>

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -450,3 +450,11 @@ class TestOtherFiles:
     def test_empty_style(self):
         path = join(TEST_ROOT, "samples", "others", "empty_style.svg")
         svglib.svg2rlg(path)
+
+    def test_convert_quadratic_to_cubic(self):
+        path = join(TEST_ROOT, "samples", "others", "quadratic_path.svg")
+        svg_root = svglib.load_svg_file(path, resolve_entities=False)
+        renderer = svglib.SvgRenderer(path)
+        drawing = renderer.render(svg_root)
+        cubic_path = "M 0 5 C 0 8.333333 1.666667 10 5 10 C 8.333333 10 10 8.333333 10 5 C 10 1.666667 8.333333 0 5 0 C 1.666667 0 0 1.666667 0 5 Z"
+        assert cubic_path in drawing.asString("svg")


### PR DESCRIPTION
I tried to fix #364 in #365 but while I had the right idea, the PR did not actually fix the problem, sorry!

I accidentally used the cubic control points to store the last quadratic control points because the var `x1`, `x2` were overwritten by the conversion call. I moved the storing of the last quadratic control point to before the conversion call. This time a test is included to make sure this works.

Fixes #364 properly.

