### PR TITLE
Replace license_file with license_files in setup.py

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ url = https://github.com/deeplook/svglib
 author = Dinu Gherman
 author_email = gherman@darwin.in-berlin.de
 license = LGPL 3
-license_file = LICENSE.txt
+license_files = LICENSE.txt
 classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console


### PR DESCRIPTION
Replace the deprecated `license_file` key with the equivalent `license_files` to fix the following deprecation warning:

    /usr/lib/python3.11/site-packages/setuptools/config/setupcfg.py:508: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
      warnings.warn(msg, warning_class)