### PR TITLE
Update svg2rlg to accept IO as path type

### DIFF
--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -30,7 +30,7 @@ import shlex
 import shutil
 from collections import defaultdict, namedtuple
 from io import BytesIO
-from typing import Any, BinaryIO, Dict, List, Optional, Tuple, Union
+from typing import Any, BinaryIO, Dict, List, Optional, TextIO, Tuple, Union
 
 from PIL import Image as PILImage
 from reportlab.graphics.shapes import (
@@ -1782,7 +1782,7 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
 
 
 def svg2rlg(
-    path: Union[str, os.PathLike[str], BinaryIO],
+    path: Union[str, os.PathLike[str], BinaryIO, TextIO],
     resolve_entities: bool = False,
     **kwargs: Any,
 ) -> Optional[Drawing]:

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -30,7 +30,7 @@ import shlex
 import shutil
 from collections import defaultdict, namedtuple
 from io import BytesIO
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, IO, List, Optional, Tuple, Union
 
 from PIL import Image as PILImage
 from reportlab.graphics.shapes import (
@@ -1782,7 +1782,7 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
 
 
 def svg2rlg(
-    path: Union[str, os.PathLike[str]], resolve_entities: bool = False, **kwargs: Any
+    path: Union[str, os.PathLike[str], IO], resolve_entities: bool = False, **kwargs: Any
 ) -> Optional[Drawing]:
     """Convert an SVG file to a ReportLab Drawing object.
 

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -30,7 +30,7 @@ import shlex
 import shutil
 from collections import defaultdict, namedtuple
 from io import BytesIO
-from typing import IO, Any, Dict, List, Optional, Tuple, Union
+from typing import Any, BinaryIO, Dict, List, Optional, Tuple, Union
 
 from PIL import Image as PILImage
 from reportlab.graphics.shapes import (
@@ -1782,7 +1782,7 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
 
 
 def svg2rlg(
-    path: Union[str, os.PathLike[str], IO],
+    path: Union[str, os.PathLike[str], BinaryIO],
     resolve_entities: bool = False,
     **kwargs: Any,
 ) -> Optional[Drawing]:

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -30,7 +30,7 @@ import shlex
 import shutil
 from collections import defaultdict, namedtuple
 from io import BytesIO
-from typing import Any, Dict, IO, List, Optional, Tuple, Union
+from typing import IO, Any, Dict, List, Optional, Tuple, Union
 
 from PIL import Image as PILImage
 from reportlab.graphics.shapes import (
@@ -1782,7 +1782,9 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
 
 
 def svg2rlg(
-    path: Union[str, os.PathLike[str], IO], resolve_entities: bool = False, **kwargs: Any
+    path: Union[str, os.PathLike[str], IO],
+    resolve_entities: bool = False,
+    **kwargs: Any,
 ) -> Optional[Drawing]:
     """Convert an SVG file to a ReportLab Drawing object.
 


### PR DESCRIPTION
On my current project, this is the only warning I get from PyCharm.
This seems to be officially supported since #173/#174