### PR TITLE
Fix case-insensitive font family lookup (issue #433)

### DIFF
--- a/src/svglib/fonts.py
+++ b/src/svglib/fonts.py
@@ -71,6 +71,7 @@ class FontMap:
         'Family-WeightStyle' (e.g., 'Arial-BoldItalic').
         """
         self._map: Dict[str, Dict[str, Union[str, bool, int]]] = {}
+        self._family_index: Dict[str, str] = {}  # lowercase family → canonical family
 
         self.register_default_fonts()
 
@@ -216,6 +217,7 @@ class FontMap:
             "rlgFont": internal_name,
             "exact": exact,
         }
+        self._family_index.setdefault(font_name.lower(), font_name)
         return font_name, exact
 
     def register_default_fonts(self) -> None:
@@ -397,6 +399,7 @@ class FontMap:
                 "rlgFont": rlgFontName,
                 "exact": True,
             }
+            self._family_index.setdefault(font_family.lower(), font_family)
             return internal_name, True
 
         if internal_name not in STANDARD_FONT_NAMES and font_path is not None:
@@ -409,6 +412,7 @@ class FontMap:
                     "rlgFont": rlgFontName,
                     "exact": True,
                 }
+                self._family_index.setdefault(font_family.lower(), font_family)
                 return internal_name, True
             except TTFError:
                 return NOT_FOUND
@@ -438,6 +442,7 @@ class FontMap:
             If no suitable font is found, falls back to DEFAULT_FONT_NAME (Helvetica).
             The search prioritizes exact matches over approximate ones.
         """
+        font_name = self._family_index.get(font_name.lower(), font_name)
         internal_name = FontMap.build_internal_name(font_name, weight, style)
         # Step 1 check if the font is one of the buildin standard fonts
         if internal_name in STANDARD_FONT_NAMES:


### PR DESCRIPTION
## Summary

- Fixes #433
- `font-family` names in SVG are case-insensitive per the CSS spec, but svglib's internal font map used a case-sensitive `dict`. This caused values like `helvetica` to miss the registered `Helvetica` entry, silently dropping bold/italic variants and falling back to the plain default font.
- Adds a `_family_index` dict (lowercase → canonical family name) to `FontMap`, populated on every `register_font` call. `find_font` now normalises the incoming family name via this index before building the internal lookup key, so `helvetica` + `weight=bold` correctly resolves to `Helvetica-Bold`.

## Test plan

- [ ] Existing font tests all pass
- [ ] `font-weight="bold"` with a lowercase `font-family` now produces a bold font variant on the resulting `String` shape