### PR TITLE
Fix KeyError when fontconfig resolves font with non-normal weight/style

### DIFF
--- a/src/svglib/fonts.py
+++ b/src/svglib/fonts.py
@@ -218,7 +218,7 @@ class FontMap:
             "exact": exact,
         }
         self._family_index.setdefault(font_name.lower(), font_name)
-        return font_name, exact
+        return internal_name, exact
 
     def register_default_fonts(self) -> None:
         """Register mappings for standard PDF fonts and common font families.


### PR DESCRIPTION
## Summary

- `use_fontconfig` registered fonts under the internal name (e.g. `serif-100` for `serif` with weight `100`) but returned the original family name (`serif`), which was never registered with ReportLab's `pdfmetrics`
- This caused `KeyError: 'serif'` when that name was later passed to `stringWidth` or `renderPM.drawToFile`
- Fix: return `internal_name` instead of `font_name` so callers receive the actually-registered font name

Reproducer: `TestW3CSVG::test_convert_pdf_png` with `text-fonts-202-t.svg` (uses `font-family="'ZalamanderCaps', serif"` with numeric font weights like `100`, `200`, etc.)

## Test plan

- [x] `TestW3CSVG::test_convert_pdf_png` passes locally (was failing with `KeyError: 'serif'`)
- [x] All other unit tests pass (`tests/test_basic.py`, `tests/test_fonts.py`, etc.)