### PR TITLE
Schedule weekly CI run on main to warm test asset caches

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,5 +1,10 @@
 name: Run Matrix Tests on MacOS
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
 jobs:
   tests:
     name: "Python ${{ matrix.python-version }} on MacOs"

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -1,5 +1,10 @@
 name: Run Matrix Tests on Ubuntu
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
 jobs:
   tests:
     name: "Python ${{ matrix.python-version }} on Ubuntu"


### PR DESCRIPTION
## Summary

- PR runs get cache misses on the first run of each week because caches saved by PR jobs aren't accessible to other branches — only `main` branch runs populate caches readable by all PRs
- Add a Monday 06:00 UTC `schedule` trigger to the Ubuntu and macOS workflows so they run on `main` weekly, saving fresh caches before PRs open that week

## Test plan

- [x] Subsequent PR runs this week should show "Cache hit" for `wikipedia-flags`, `wikipedia-symbols`, and `w3c-svg12-tinytestsuite` cache steps