### PR TITLE
Fix fill-rule not applied to paths

### DIFF
--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -1707,7 +1707,7 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
         mappingN = (
             (["fill"], "fillColor", "convertColor", ["black"]),
             (["fill-opacity"], "fillOpacity", "convertOpacity", [1]),
-            (["fill-rule"], "_fillRule", "convertFillRule", ["nonzero"]),
+            (["fill-rule"], "fillMode", "convertFillRule", ["nonzero"]),
             (["stroke"], "strokeColor", "convertColor", ["none"]),
             (["stroke-width"], "strokeWidth", "convertLength", ["1"]),
             (["stroke-opacity"], "strokeOpacity", "convertOpacity", [1]),

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -543,7 +543,7 @@ class TestAttrConverter:
         node = minimal_svg_node('<polygon fill-rule="evenodd"/>')
         poly = Polygon()
         converter.applyStyleOnShape(poly, node)
-        assert poly._fillRule == FILL_EVEN_ODD
+        assert poly.fillMode == FILL_EVEN_ODD
 
     def test_stroke(self):
         converter = svglib.Svg2RlgShapeConverter(None)


### PR DESCRIPTION
## Summary

- svglib stored the converted `fill-rule` in `path._fillRule`, but ReportLab's `renderPDF` reads `path.fillMode` — a built-in `Path` attribute that defaults to `FILL_EVEN_ODD` (0)
- Because `fillMode` was never written, every SVG path rendered with even-odd fill regardless of the `fill-rule` attribute
- Self-intersecting paths (like the star in the Algeria flag) appeared hollow in the output PDF/PNG — the classic symptom of evenodd being applied to a winding=2 interior
- Fix: write `path.fillMode` directly instead of `path._fillRule`

## Root cause detail

`reportlab.graphics.shapes.Path` already has `fillMode` as a property (default `0` = `FILL_EVEN_ODD`). `renderPDF.drawPath` reads it with `getattr(path, 'fillMode', None)`. The monkeypatch in `monkeypatch_reportlab()` was attempting to bridge `_fillRule` → rendering, but was writing to a non-existent `canvas.fillMode` attribute instead of `canvas._fillMode`, so it was silently a no-op.

## Test plan

- [x] All unit tests pass
- [x] Algeria flag star now fills correctly (visually verified by regenerating the PDF)
- [x] `test_fillrule` updated to assert `fillMode` instead of `_fillRule`