### PR TITLE
Add SVG gradient support (linearGradient and radialGradient)

### DIFF
--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -36,6 +36,7 @@ from PIL import Image as PILImage
 from reportlab.graphics.shapes import (
     _CLOSEPATH,
     Circle,
+    DirectDraw,
     Drawing,
     Ellipse,
     Group,
@@ -47,6 +48,7 @@ from reportlab.graphics.shapes import (
     Rect,
     SolidShape,
     String,
+    _renderPath,
 )
 from reportlab.lib import colors
 from reportlab.lib.units import pica, toLength
@@ -526,6 +528,10 @@ class Svg2RlgAttributeConverter(AttributeConverter):
         if not text or text == "none":
             return None
 
+        # Gradient/pattern references are handled at the renderer level.
+        if text.startswith("url("):
+            return None
+
         if text == "currentColor":
             return "currentColor"
         if len(text) in (7, 9) and text[0] == "#":
@@ -687,6 +693,160 @@ class ExternalSVG:
         return self.renderer.definitions.get(fragment)
 
 
+_BEZIER_KAPPA = 0.5523  # cubic bezier constant for circle approximation
+
+_GRADIENT_URL_RE = re.compile(r"url\(#([^)]+)\)")
+
+
+def _shape_to_pdf_path(canvas, shape):
+    """Convert a ReportLab shape to a PDFPathObject for use as a clip path.
+
+    Handles Path, Rect, Circle, Ellipse, and Polygon; falls back to the
+    shape's bounding box for other types.
+    """
+    pdfPath = canvas.beginPath()
+    if isinstance(shape, Path):
+        draw_funcs = (pdfPath.moveTo, pdfPath.lineTo, pdfPath.curveTo, pdfPath.close)
+        _renderPath(shape, draw_funcs)
+    elif isinstance(shape, Rect):
+        x, y, x2, y2 = shape.getBounds()
+        w, h = x2 - x, y2 - y
+        rx = min(getattr(shape, "rx", 0) or 0, w / 2)
+        ry = min(getattr(shape, "ry", 0) or 0, h / 2)
+        k = _BEZIER_KAPPA
+        if rx or ry:
+            pdfPath.moveTo(x + rx, y)
+            pdfPath.lineTo(x + w - rx, y)
+            pdfPath.curveTo(
+                x + w - rx + rx * k, y, x + w, y + ry - ry * k, x + w, y + ry
+            )
+            pdfPath.lineTo(x + w, y + h - ry)
+            pdfPath.curveTo(
+                x + w,
+                y + h - ry + ry * k,
+                x + w - rx + rx * k,
+                y + h,
+                x + w - rx,
+                y + h,
+            )
+            pdfPath.lineTo(x + rx, y + h)
+            pdfPath.curveTo(
+                x + rx - rx * k, y + h, x, y + h - ry + ry * k, x, y + h - ry
+            )
+            pdfPath.lineTo(x, y + ry)
+            pdfPath.curveTo(x, y + ry - ry * k, x + rx - rx * k, y, x + rx, y)
+            pdfPath.close()
+        else:
+            pdfPath.moveTo(x, y)
+            pdfPath.lineTo(x + w, y)
+            pdfPath.lineTo(x + w, y + h)
+            pdfPath.lineTo(x, y + h)
+            pdfPath.close()
+    elif isinstance(shape, Circle):
+        cx, cy, r = shape.cx, shape.cy, shape.r
+        k = _BEZIER_KAPPA
+        pdfPath.moveTo(cx + r, cy)
+        pdfPath.curveTo(cx + r, cy + r * k, cx + r * k, cy + r, cx, cy + r)
+        pdfPath.curveTo(cx - r * k, cy + r, cx - r, cy + r * k, cx - r, cy)
+        pdfPath.curveTo(cx - r, cy - r * k, cx - r * k, cy - r, cx, cy - r)
+        pdfPath.curveTo(cx + r * k, cy - r, cx + r, cy - r * k, cx + r, cy)
+        pdfPath.close()
+    elif isinstance(shape, Ellipse):
+        cx, cy = shape.cx, shape.cy
+        rx, ry = shape.rx, shape.ry
+        k = _BEZIER_KAPPA
+        pdfPath.moveTo(cx + rx, cy)
+        pdfPath.curveTo(cx + rx, cy + ry * k, cx + rx * k, cy + ry, cx, cy + ry)
+        pdfPath.curveTo(cx - rx * k, cy + ry, cx - rx, cy + ry * k, cx - rx, cy)
+        pdfPath.curveTo(cx - rx, cy - ry * k, cx - rx * k, cy - ry, cx, cy - ry)
+        pdfPath.curveTo(cx + rx * k, cy - ry, cx + rx, cy - ry * k, cx + rx, cy)
+        pdfPath.close()
+    elif isinstance(shape, Polygon):
+        pts = shape.points
+        if len(pts) >= 2:
+            pdfPath.moveTo(pts[0], pts[1])
+            for i in range(2, len(pts) - 1, 2):
+                pdfPath.lineTo(pts[i], pts[i + 1])
+            pdfPath.close()
+    else:
+        try:
+            x, y, x2, y2 = shape.getBounds()
+            pdfPath.moveTo(x, y)
+            pdfPath.lineTo(x2, y)
+            pdfPath.lineTo(x2, y2)
+            pdfPath.lineTo(x, y2)
+            pdfPath.close()
+        except Exception:
+            pass
+    return pdfPath
+
+
+def _find_clip_shape(item):
+    """Return the first Path/Rect/Circle/Ellipse/Polygon found in item or its group."""
+    if isinstance(item, (Path, Rect, Circle, Ellipse, Polygon)):
+        return item
+    if isinstance(item, Group):
+        for child in item.contents:
+            found = _find_clip_shape(child)
+            if found is not None:
+                return found
+    return None
+
+
+class _LinearGradientShape(DirectDraw):
+    """Fills a clipped region with a linear gradient via PDF shading."""
+
+    def __init__(self, clip_shape, x0, y0, x1, y1, rl_colors, positions, extend=True):
+        self._clip_shape = clip_shape
+        self._x0, self._y0 = x0, y0
+        self._x1, self._y1 = x1, y1
+        self._rl_colors = rl_colors
+        self._positions = positions
+        self._extend = extend
+
+    def drawDirectly(self, renderer):
+        canvas = renderer._canvas
+        canvas.saveState()
+        pdfPath = _shape_to_pdf_path(canvas, self._clip_shape)
+        canvas.clipPath(pdfPath, fill=1, stroke=0)
+        canvas.linearGradient(
+            self._x0,
+            self._y0,
+            self._x1,
+            self._y1,
+            self._rl_colors,
+            self._positions,
+            self._extend,
+        )
+        canvas.restoreState()
+
+
+class _RadialGradientShape(DirectDraw):
+    """Fills a clipped region with a radial gradient via PDF shading."""
+
+    def __init__(self, clip_shape, cx, cy, r, rl_colors, positions, extend=True):
+        self._clip_shape = clip_shape
+        self._cx, self._cy, self._r = cx, cy, r
+        self._rl_colors = rl_colors
+        self._positions = positions
+        self._extend = extend
+
+    def drawDirectly(self, renderer):
+        canvas = renderer._canvas
+        canvas.saveState()
+        pdfPath = _shape_to_pdf_path(canvas, self._clip_shape)
+        canvas.clipPath(pdfPath, fill=1, stroke=0)
+        canvas.radialGradient(
+            self._cx,
+            self._cy,
+            self._r,
+            self._rl_colors,
+            self._positions,
+            self._extend,
+        )
+        canvas.restoreState()
+
+
 # ## the main meat ###
 
 
@@ -712,6 +872,7 @@ class SvgRenderer:
         self.shape_converter = Svg2RlgShapeConverter(path, self.attrConverter)
         self.handled_shapes = self.shape_converter.get_handled_shapes()
         self.definitions: Dict[str, Any] = {}
+        self.gradient_defs: Dict[str, dict] = {}
         self.waiting_use_nodes: Dict[str, List[Tuple[NodeTracker, Optional[Any]]]] = (
             defaultdict(list)
         )
@@ -788,6 +949,9 @@ class SvgRenderer:
             parent.add(item)
         elif name == "clipPath":
             item = self.renderG(node)
+        elif name in ("linearGradient", "radialGradient"):
+            self.renderGradient(node)
+            ignored = True
         elif name in self.handled_shapes:
             if name == "image":
                 # We resolve the image target at renderer level because it can point
@@ -810,6 +974,13 @@ class SvgRenderer:
             item = self.shape_converter.convertShape(name, node, clipping)
             display = node.getAttribute("display")
             if item and display != "none":
+                fill_val = self.attrConverter.findAttr(node, "fill")
+                m = _GRADIENT_URL_RE.fullmatch(fill_val.strip()) if fill_val else None
+                if m:
+                    grad_id = m.group(1)
+                    grad_def = self._resolve_gradient(grad_id)
+                    if grad_def is not None:
+                        item = self._apply_gradient_fill(item, grad_def)
                 parent.add(item)
         else:
             ignored = True
@@ -833,6 +1004,171 @@ class SvgRenderer:
                 for use_node, group in to_render:
                     self.renderUse(use_node, group=group)
             self.print_unused_attributes(node)
+
+    def renderGradient(self, node: NodeTracker) -> None:
+        """Parse a <linearGradient> or <radialGradient> element and store it."""
+        grad_id = node.attrib.get("id")
+        if not grad_id:
+            return
+        grad_type = node_name(node)  # "linearGradient" or "radialGradient"
+
+        def _float_attr(attr, default):
+            raw = node.attrib.get(attr, "").strip()
+            if raw.endswith("%"):
+                try:
+                    return float(raw[:-1]) / 100.0
+                except ValueError:
+                    return default
+            try:
+                return float(raw) if raw else default
+            except ValueError:
+                return default
+
+        href = node.attrib.get("{http://www.w3.org/1999/xlink}href") or node.attrib.get(
+            "href", ""
+        )
+        href_id = href.lstrip("#") if href.startswith("#") else None
+
+        grad_units = node.attrib.get("gradientUnits", "objectBoundingBox")
+        spread = node.attrib.get("spreadMethod", "pad")
+
+        # Collect stop elements (direct children with tag "stop")
+        stops = []
+        for child in node:
+            child_name = node_name(child)
+            if child_name != "stop":
+                continue
+            raw_offset = child.attrib.get("offset", "0").strip()
+            if raw_offset.endswith("%"):
+                try:
+                    offset = float(raw_offset[:-1]) / 100.0
+                except ValueError:
+                    offset = 0.0
+            else:
+                try:
+                    offset = float(raw_offset)
+                except ValueError:
+                    offset = 0.0
+
+            # stop-color and stop-opacity can be in style or as direct attrs
+            style_str = child.attrib.get("style", "")
+            style_attrs: dict = {}
+            if style_str:
+                style_attrs = self.attrConverter.parseMultiAttributes(style_str)
+
+            stop_color_str = style_attrs.get(
+                "stop-color", child.attrib.get("stop-color", "black")
+            )
+            stop_opacity_str = style_attrs.get(
+                "stop-opacity", child.attrib.get("stop-opacity", "1")
+            )
+            try:
+                opacity = float(stop_opacity_str)
+            except (ValueError, TypeError):
+                opacity = 1.0
+
+            rl_color = self.attrConverter.convertColor(stop_color_str)
+            if rl_color is None:
+                rl_color = colors.black
+            rl_color = rl_color.clone()
+            rl_color.alpha = opacity
+            stops.append((offset, rl_color))
+
+        grad_def: dict = {
+            "type": "linear" if grad_type == "linearGradient" else "radial",
+            "gradientUnits": grad_units,
+            "spreadMethod": spread,
+            "stops": stops,
+            "href": href_id,
+        }
+
+        if grad_type == "linearGradient":
+            grad_def["x1"] = _float_attr("x1", 0.0)
+            grad_def["y1"] = _float_attr("y1", 0.0)
+            grad_def["x2"] = _float_attr("x2", 1.0)
+            grad_def["y2"] = _float_attr("y2", 0.0)
+        else:
+            grad_def["cx"] = _float_attr("cx", 0.5)
+            grad_def["cy"] = _float_attr("cy", 0.5)
+            grad_def["r"] = _float_attr("r", 0.5)
+            grad_def["fx"] = _float_attr("fx", grad_def["cx"])
+            grad_def["fy"] = _float_attr("fy", grad_def["cy"])
+
+        self.gradient_defs[grad_id] = grad_def
+
+    def _resolve_gradient(self, grad_id: str) -> Optional[dict]:
+        """Return a fully resolved gradient dict, following xlink:href chains."""
+        visited = set()
+        result = self.gradient_defs.get(grad_id)
+        while result is not None:
+            href = result.get("href")
+            if not href or href in visited:
+                break
+            parent = self.gradient_defs.get(href)
+            if parent is None:
+                break
+            visited.add(href)
+            # Merge: current overrides parent for all keys except missing stops
+            merged = dict(parent)
+            for k, v in result.items():
+                if k == "stops" and not v:
+                    continue  # inherit parent's stops
+                merged[k] = v
+            result = merged
+        return result
+
+    def _apply_gradient_fill(self, item: Any, grad_def: dict) -> Any:
+        """Wrap a shape in a Group that paints the gradient fill then the stroke."""
+        clip_shape = _find_clip_shape(item)
+        if clip_shape is None:
+            return item
+
+        stops = grad_def.get("stops", [])
+        if not stops:
+            return item
+
+        positions = [s[0] for s in stops]
+        rl_colors = [s[1] for s in stops]
+        extend = grad_def.get("spreadMethod", "pad") == "pad"
+        grad_units = grad_def.get("gradientUnits", "objectBoundingBox")
+
+        if grad_units == "objectBoundingBox":
+            try:
+                bx0, by0, bx1, by1 = clip_shape.getBounds()
+            except Exception:
+                return item
+            bbox_w = bx1 - bx0
+            bbox_h = by1 - by0
+        else:
+            bx0 = by0 = bbox_w = bbox_h = 0.0  # unused for userSpaceOnUse
+
+        if grad_def["type"] == "linear":
+            x1, y1 = grad_def.get("x1", 0.0), grad_def.get("y1", 0.0)
+            x2, y2 = grad_def.get("x2", 1.0), grad_def.get("y2", 0.0)
+            if grad_units == "objectBoundingBox":
+                x1 = bx0 + x1 * bbox_w
+                y1 = by0 + y1 * bbox_h
+                x2 = bx0 + x2 * bbox_w
+                y2 = by0 + y2 * bbox_h
+            grad_shape: DirectDraw = _LinearGradientShape(
+                clip_shape, x1, y1, x2, y2, rl_colors, positions, extend
+            )
+        else:
+            cx = grad_def.get("cx", 0.5)
+            cy = grad_def.get("cy", 0.5)
+            r = grad_def.get("r", 0.5)
+            if grad_units == "objectBoundingBox":
+                cx = bx0 + cx * bbox_w
+                cy = by0 + cy * bbox_h
+                r = r * (bbox_w + bbox_h) / 2.0
+            grad_shape = _RadialGradientShape(
+                clip_shape, cx, cy, r, rl_colors, positions, extend
+            )
+
+        group = Group()
+        group.add(grad_shape)
+        group.add(item)
+        return group
 
     def get_clippath(self, node: NodeTracker) -> Optional[Any]:
         """Get the clipping path object referenced by a node's 'clip-path' attribute.

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -777,7 +777,9 @@ def _shape_to_pdf_path(canvas, shape):
             pdfPath.lineTo(x, y2)
             pdfPath.close()
         except Exception:
-            pass
+            logger.debug(
+                "Cannot compute bounding box for clip path fallback", exc_info=True
+            )
     return pdfPath
 
 
@@ -1136,6 +1138,7 @@ class SvgRenderer:
             try:
                 bx0, by0, bx1, by1 = clip_shape.getBounds()
             except Exception:
+                logger.debug("Cannot compute bounding box for gradient", exc_info=True)
                 return item
             bbox_w = bx1 - bx0
             bbox_h = by1 - by0

--- a/tests/samples/misc/gradient_showcase.svg
+++ b/tests/samples/misc/gradient_showcase.svg
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  gradient_showcase.svg — exercises linearGradient and radialGradient on
+  a variety of shapes: rect, circle, ellipse, polygon, polyline, path,
+  and multi-stop / inherited / userSpaceOnUse / semi-transparent variants.
+-->
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="600" height="900"
+     viewBox="0 0 600 900">
+
+  <defs>
+
+    <!-- ── Linear gradients ── -->
+
+    <!-- Horizontal: three stops -->
+    <linearGradient id="g-horiz" x1="0" y1="0" x2="1" y2="0"
+                    gradientUnits="objectBoundingBox">
+      <stop offset="0"   stop-color="#e74c3c"/>
+      <stop offset="0.5" stop-color="#f39c12"/>
+      <stop offset="1"   stop-color="#2ecc71"/>
+    </linearGradient>
+
+    <!-- Vertical: dark-to-sky -->
+    <linearGradient id="g-vert" x1="0" y1="0" x2="0" y2="1"
+                    gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#2c3e50"/>
+      <stop offset="1" stop-color="#3498db"/>
+    </linearGradient>
+
+    <!-- Diagonal: purple-to-gold -->
+    <linearGradient id="g-diag" x1="0" y1="0" x2="1" y2="1"
+                    gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="#8e44ad"/>
+      <stop offset="1" stop-color="#f1c40f"/>
+    </linearGradient>
+
+    <!-- userSpaceOnUse: absolute canvas coordinates -->
+    <linearGradient id="g-userspace"
+                    x1="30" y1="0" x2="270" y2="0"
+                    gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1abc9c"/>
+      <stop offset="1" stop-color="#c0392b"/>
+    </linearGradient>
+
+    <!-- Base gradient — stops only, no geometry (used via href) -->
+    <linearGradient id="g-base-stops">
+      <stop offset="0"   stop-color="#e74c3c"/>
+      <stop offset="0.5" stop-color="#f39c12"/>
+      <stop offset="1"   stop-color="#2ecc71"/>
+    </linearGradient>
+
+    <!-- Inherited: same stops as g-base-stops, but applied vertically -->
+    <linearGradient id="g-inherited" xlink:href="#g-base-stops"
+                    x1="0" y1="0" x2="0" y2="1"
+                    gradientUnits="objectBoundingBox"/>
+
+    <!-- Four-stop rainbow -->
+    <linearGradient id="g-rainbow" x1="0" y1="0" x2="1" y2="0"
+                    gradientUnits="objectBoundingBox">
+      <stop offset="0"    stop-color="#e74c3c"/>
+      <stop offset="0.33" stop-color="#f1c40f"/>
+      <stop offset="0.67" stop-color="#2980b9"/>
+      <stop offset="1"    stop-color="#8e44ad"/>
+    </linearGradient>
+
+    <!-- ── Radial gradients ── -->
+
+    <!-- Centred: white core, red rim -->
+    <radialGradient id="g-radial-center" cx="0.5" cy="0.5" r="0.5"
+                    gradientUnits="objectBoundingBox">
+      <stop offset="0" stop-color="white"/>
+      <stop offset="1" stop-color="#e74c3c"/>
+    </radialGradient>
+
+    <!-- Off-centre focal point: glossy sphere look -->
+    <radialGradient id="g-radial-offcenter" cx="0.35" cy="0.35" r="0.6"
+                    gradientUnits="objectBoundingBox">
+      <stop offset="0"   stop-color="white"   stop-opacity="1"/>
+      <stop offset="0.4" stop-color="#3498db" stop-opacity="1"/>
+      <stop offset="1"   stop-color="#1a252f" stop-opacity="1"/>
+    </radialGradient>
+
+    <!-- Glass-button: semi-transparent -->
+    <radialGradient id="g-glass" cx="0.4" cy="0.3" r="0.55"
+                    gradientUnits="objectBoundingBox">
+      <stop offset="0"   stop-color="white"   stop-opacity="0.85"/>
+      <stop offset="0.5" stop-color="#2980b9" stop-opacity="0.5"/>
+      <stop offset="1"   stop-color="#1a252f" stop-opacity="0.9"/>
+    </radialGradient>
+
+    <!-- Golden sun burst -->
+    <radialGradient id="g-sun" cx="0.5" cy="0.5" r="0.5"
+                    gradientUnits="objectBoundingBox">
+      <stop offset="0"   stop-color="#fff176"/>
+      <stop offset="0.5" stop-color="#f39c12"/>
+      <stop offset="1"   stop-color="#e74c3c" stop-opacity="0"/>
+    </radialGradient>
+
+  </defs>
+
+  <!-- ════════════════════════════════════════════
+       Section label helper
+       ════════════════════════════════════════════ -->
+
+  <rect x="0" y="0" width="600" height="900" fill="#f8f8f8"/>
+
+  <!-- ── Row 1: rect shapes ── -->
+  <text x="16" y="22" font-size="11" fill="#555" font-family="Helvetica">
+    Rects
+  </text>
+
+  <!-- Horizontal -->
+  <rect x="16"  y="30" width="170" height="60"
+        fill="url(#g-horiz)" stroke="#333" stroke-width="1"/>
+  <text x="16"  y="102" font-size="9" fill="#666" font-family="Helvetica">horizontal 3-stop</text>
+
+  <!-- Vertical -->
+  <rect x="214" y="30" width="170" height="60"
+        fill="url(#g-vert)" stroke="#333" stroke-width="1"/>
+  <text x="214" y="102" font-size="9" fill="#666" font-family="Helvetica">vertical</text>
+
+  <!-- Diagonal -->
+  <rect x="412" y="30" width="170" height="60"
+        fill="url(#g-diag)" stroke="#333" stroke-width="1"/>
+  <text x="412" y="102" font-size="9" fill="#666" font-family="Helvetica">diagonal</text>
+
+  <!-- ── Row 2: more rects ── -->
+  <rect x="16"  y="112" width="170" height="60"
+        fill="url(#g-rainbow)" stroke="#333" stroke-width="1"/>
+  <text x="16"  y="184" font-size="9" fill="#666" font-family="Helvetica">4-stop rainbow</text>
+
+  <rect x="214" y="112" width="170" height="60"
+        fill="url(#g-inherited)" stroke="#333" stroke-width="1"/>
+  <text x="214" y="184" font-size="9" fill="#666" font-family="Helvetica">inherited (vertical via xlink:href)</text>
+
+  <rect x="412" y="112" width="170" height="60"
+        fill="url(#g-userspace)" stroke="#333" stroke-width="1"/>
+  <text x="412" y="184" font-size="9" fill="#666" font-family="Helvetica">userSpaceOnUse</text>
+
+  <!-- ── Row 3: rounded rects ── -->
+  <text x="16" y="200" font-size="11" fill="#555" font-family="Helvetica">
+    Rounded rects
+  </text>
+
+  <rect x="16"  y="208" width="170" height="60" rx="20" ry="20"
+        fill="url(#g-horiz)" stroke="#333" stroke-width="1"/>
+  <text x="16"  y="280" font-size="9" fill="#666" font-family="Helvetica">horizontal</text>
+
+  <rect x="214" y="208" width="170" height="60" rx="30" ry="15"
+        fill="url(#g-vert)" stroke="#333" stroke-width="1"/>
+  <text x="214" y="280" font-size="9" fill="#666" font-family="Helvetica">vertical</text>
+
+  <rect x="412" y="208" width="170" height="60" rx="20" ry="20"
+        fill="url(#g-radial-center)" stroke="#333" stroke-width="1"/>
+  <text x="412" y="280" font-size="9" fill="#666" font-family="Helvetica">radial centred</text>
+
+  <!-- ── Row 4: circles and ellipses ── -->
+  <text x="16" y="296" font-size="11" fill="#555" font-family="Helvetica">
+    Circles &amp; ellipses
+  </text>
+
+  <circle cx="101" cy="345" r="45"
+          fill="url(#g-radial-center)" stroke="#888" stroke-width="1"/>
+  <text x="16"  y="402" font-size="9" fill="#666" font-family="Helvetica">radial centred</text>
+
+  <circle cx="299" cy="345" r="45"
+          fill="url(#g-radial-offcenter)" stroke="#555" stroke-width="1"/>
+  <text x="214" y="402" font-size="9" fill="#666" font-family="Helvetica">off-centre radial</text>
+
+  <circle cx="497" cy="345" r="45"
+          fill="url(#g-glass)" stroke="#2c3e50" stroke-width="1"/>
+  <text x="412" y="402" font-size="9" fill="#666" font-family="Helvetica">glass radial (semi-transparent)</text>
+
+  <ellipse cx="101" cy="448" rx="85" ry="38"
+           fill="url(#g-horiz)" stroke="#333" stroke-width="1"/>
+  <text x="16"  y="496" font-size="9" fill="#666" font-family="Helvetica">ellipse / horizontal</text>
+
+  <ellipse cx="299" cy="448" rx="85" ry="38"
+           fill="url(#g-glass)" stroke="#2c3e50" stroke-width="2"/>
+  <text x="214" y="496" font-size="9" fill="#666" font-family="Helvetica">ellipse / glass radial</text>
+
+  <ellipse cx="497" cy="448" rx="85" ry="38"
+           fill="url(#g-sun)" stroke="#e67e22" stroke-width="1"/>
+  <text x="412" y="496" font-size="9" fill="#666" font-family="Helvetica">ellipse / sun burst (fade-out)</text>
+
+  <!-- ── Row 5: polygons ── -->
+  <text x="16" y="512" font-size="11" fill="#555" font-family="Helvetica">
+    Polygons
+  </text>
+
+  <!-- Triangle -->
+  <polygon points="101,520 16,660 186,660"
+           fill="url(#g-vert)" stroke="#2c3e50" stroke-width="2"/>
+  <text x="16"  y="674" font-size="9" fill="#666" font-family="Helvetica">triangle / vertical</text>
+
+  <!-- Pentagon -->
+  <polygon points="299,520 370,575 344,660 254,660 228,575"
+           fill="url(#g-diag)" stroke="#8e44ad" stroke-width="2"/>
+  <text x="214" y="674" font-size="9" fill="#666" font-family="Helvetica">pentagon / diagonal</text>
+
+  <!-- Star (6 points) -->
+  <polygon points="497,520 514,568 565,568 524,597 540,645 497,618 454,645 470,597 429,568 480,568"
+           fill="url(#g-radial-offcenter)" stroke="#1a252f" stroke-width="1.5"/>
+  <text x="412" y="674" font-size="9" fill="#666" font-family="Helvetica">star / off-centre radial</text>
+
+  <!-- ── Row 6: paths ── -->
+  <text x="16" y="690" font-size="11" fill="#555" font-family="Helvetica">
+    Paths
+  </text>
+
+  <!-- Curved closed path (leaf) -->
+  <path d="M101,700 C140,690 186,730 186,760 C186,790 140,830 101,820
+           C62,830 16,790 16,760 C16,730 62,690 101,700 Z"
+        fill="url(#g-sun)" stroke="#e67e22" stroke-width="1.5"/>
+  <text x="16"  y="844" font-size="9" fill="#666" font-family="Helvetica">closed path (leaf) / sun burst</text>
+
+  <!-- Right-angle triangle via path -->
+  <path d="M214,700 L384,700 L384,840 Z"
+        fill="url(#g-rainbow)" stroke="#8e44ad" stroke-width="1.5"/>
+  <text x="214" y="856" font-size="9" fill="#666" font-family="Helvetica">path triangle / rainbow</text>
+
+  <!-- Arrow shape -->
+  <path d="M412,760 L480,700 L480,730 L582,730 L582,790 L480,790 L480,820 Z"
+        fill="url(#g-horiz)" stroke="#e74c3c" stroke-width="1.5"/>
+  <text x="412" y="844" font-size="9" fill="#666" font-family="Helvetica">arrow path / horizontal</text>
+
+</svg>

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1289,3 +1289,160 @@ class TestEmbedded:
         # FIXME: test the error log when we can require pytest >= 3.4
         # No image as relative path in file-like input cannot be determined.
         assert drawing.contents[0].contents == []
+
+
+class TestGradients:
+    """Tests for SVG linearGradient and radialGradient support."""
+
+    @staticmethod
+    def _find_groups(shape):
+        """Recursively collect all Group objects in a drawing."""
+        from reportlab.graphics.shapes import Group as RLGroup
+
+        result = []
+        if isinstance(shape, RLGroup):
+            result.append(shape)
+        if hasattr(shape, "contents"):
+            for item in shape.contents:
+                result.extend(TestGradients._find_groups(item))
+        return result
+
+    def test_linear_gradient_rect(self):
+        """A rect with a linearGradient fill must produce a Group (not a bare Rect)."""
+        drawing = drawing_from_svg(
+            """
+            <?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+                <defs>
+                    <linearGradient id="grad1" x1="0" y1="0" x2="1" y2="0"
+                                    gradientUnits="objectBoundingBox">
+                        <stop offset="0" stop-color="red" stop-opacity="1"/>
+                        <stop offset="1" stop-color="blue" stop-opacity="1"/>
+                    </linearGradient>
+                </defs>
+                <rect x="10" y="10" width="80" height="80" fill="url(#grad1)"/>
+            </svg>
+        """
+        )
+        groups = self._find_groups(drawing)
+        # The rect's fill must have been replaced by a gradient group
+        assert len(groups) > 1
+
+    def test_radial_gradient_circle(self):
+        """A circle with a radialGradient fill must produce a Group."""
+        drawing = drawing_from_svg(
+            """
+            <?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+                <defs>
+                    <radialGradient id="rgrad" cx="0.5" cy="0.5" r="0.5"
+                                    gradientUnits="objectBoundingBox">
+                        <stop offset="0" stop-color="yellow" stop-opacity="1"/>
+                        <stop offset="1" stop-color="green" stop-opacity="1"/>
+                    </radialGradient>
+                </defs>
+                <circle cx="50" cy="50" r="40" fill="url(#rgrad)"/>
+            </svg>
+        """
+        )
+        groups = self._find_groups(drawing)
+        assert len(groups) > 1
+
+    def test_gradient_stops_parsed(self):
+        """Stop colors and offsets must be correctly stored in gradient_defs."""
+        from io import BytesIO
+
+        from svglib.svglib import SvgRenderer, load_svg_file
+
+        svg_content = b"""<?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+                <defs>
+                    <linearGradient id="g1">
+                        <stop offset="0" stop-color="#ff0000" stop-opacity="1"/>
+                        <stop offset="0.5" stop-color="#00ff00" stop-opacity="0.5"/>
+                        <stop offset="1" stop-color="#0000ff" stop-opacity="1"/>
+                    </linearGradient>
+                </defs>
+            </svg>"""
+        root = load_svg_file(BytesIO(svg_content))
+        renderer = SvgRenderer("")
+        renderer.render(root)
+        grad = renderer.gradient_defs.get("g1")
+        assert grad is not None
+        assert len(grad["stops"]) == 3
+        assert grad["stops"][0][0] == 0.0
+        assert grad["stops"][1][0] == 0.5
+        assert grad["stops"][2][0] == 1.0
+
+    def test_gradient_href_inheritance(self):
+        """A gradient that references another via href must inherit its stops."""
+        from io import BytesIO
+
+        from svglib.svglib import SvgRenderer, load_svg_file
+
+        svg_content = b"""<?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 width="100" height="100">
+                <defs>
+                    <linearGradient id="base">
+                        <stop offset="0" stop-color="red"/>
+                        <stop offset="1" stop-color="blue"/>
+                    </linearGradient>
+                    <linearGradient id="derived" xlink:href="#base"
+                                    x1="0" y1="0" x2="0" y2="1"/>
+                </defs>
+            </svg>"""
+        root = load_svg_file(BytesIO(svg_content))
+        renderer = SvgRenderer("")
+        renderer.render(root)
+        resolved = renderer._resolve_gradient("derived")
+        assert resolved is not None
+        assert len(resolved["stops"]) == 2  # inherited from "base"
+        assert resolved["x2"] == 0.0  # from derived
+        assert resolved["y2"] == 1.0  # from derived
+
+    def test_gradient_userSpaceOnUse(self):
+        """A gradient with gradientUnits=userSpaceOnUse must also produce a Group."""
+        drawing = drawing_from_svg(
+            """
+            <?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+                <defs>
+                    <linearGradient id="usg" x1="0" y1="0" x2="200" y2="0"
+                                    gradientUnits="userSpaceOnUse">
+                        <stop offset="0" stop-color="black"/>
+                        <stop offset="1" stop-color="white"/>
+                    </linearGradient>
+                </defs>
+                <rect x="0" y="0" width="200" height="200" fill="url(#usg)"/>
+            </svg>
+        """
+        )
+        groups = self._find_groups(drawing)
+        assert len(groups) > 1
+
+    def test_gradient_stop_opacity_in_style(self):
+        """Stop opacity specified in a style attribute must be respected."""
+        from io import BytesIO
+
+        from svglib.svglib import SvgRenderer, load_svg_file
+
+        svg_content = b"""<?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+                <defs>
+                    <linearGradient id="g2">
+                        <stop offset="0"
+                              style="stop-color:rgb(255,0,0);stop-opacity:0.5"/>
+                        <stop offset="1"
+                              style="stop-color:#0000ff;stop-opacity:1"/>
+                    </linearGradient>
+                </defs>
+            </svg>"""
+        root = load_svg_file(BytesIO(svg_content))
+        renderer = SvgRenderer("")
+        renderer.render(root)
+        grad = renderer.gradient_defs.get("g2")
+        assert grad is not None
+        stop0_color = grad["stops"][0][1]
+        assert stop0_color.alpha == pytest.approx(0.5)


### PR DESCRIPTION
## Summary

- Implements `<linearGradient>` and `<radialGradient>` SVG elements, removing the long-standing "color gradients are not supported" limitation
- Parses gradient definitions from `<defs>` (stop colors, offsets, stop-opacity, coordinate attributes, `xlink:href` inheritance)
- Detects `fill="url(#id)"` references on shapes and wraps them in a gradient-filled group
- Renders via ReportLab's PDF shading API (`PDFAxialShading` / `PDFRadialShading`) using a `DirectDraw` subclass that clips to the shape's outline before painting the gradient
- Supports both `objectBoundingBox` (default) and `userSpaceOnUse` coordinate systems
- Silences the spurious `"Can't handle color: url(...)"` warning for gradient references

**Shapes supported:** `rect`, `circle`, `ellipse`, `polygon`, `path` (and any shape with a bounding box as fallback)

**Out of scope for this PR:** `spreadMethod=reflect/repeat`, gradient fills on `text`, `pattern` fills

## Technical approach

`reportlab.graphics.shapes.DirectDraw` is the hook that lets a custom object call raw canvas methods during rendering. Two subclasses (`_LinearGradientShape`, `_RadialGradientShape`) are added: when drawn, they:
1. Save canvas state
2. Clip to the shape's outline (`canvas.clipPath(...)`)
3. Paint the gradient (`canvas.linearGradient(...)` / `canvas.radialGradient(...)`)
4. Restore canvas state

The original shape (with `fillColor=None`) is then drawn on top for the stroke.

## Test plan

- [ ] `TestGradients::test_linear_gradient_rect` — rect with linear gradient produces a Group
- [ ] `TestGradients::test_radial_gradient_circle` — circle with radial gradient produces a Group
- [ ] `TestGradients::test_gradient_stops_parsed` — stop offsets and colors are stored correctly
- [ ] `TestGradients::test_gradient_href_inheritance` — inherited stops and overridden coords work
- [ ] `TestGradients::test_gradient_userSpaceOnUse` — `userSpaceOnUse` coords produce a Group
- [ ] `TestGradients::test_gradient_stop_opacity_in_style` — stop-opacity in `style=""` attribute respected
- [ ] Full suite: `uv run pytest tests/test_basic.py -q` → 68 passed