### PR TITLE
Switch to PEP 735 dependency groups

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -51,7 +51,7 @@ jobs:
           path: "tests/samples/W3C_SVG_12_TinyTestSuite"
           key: "w3c-svg12-tinytestsuite-macos-${{ steps.week.outputs.week }}"
       - name: "Install dependencies"
-        run: uv pip install -e .[dev]
+        run: uv pip install -e . --group dev
 
       - name: "Run tests for ${{ matrix.python-version }}"
         run: uv run pytest

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -48,7 +48,7 @@ jobs:
           path: "tests/samples/W3C_SVG_12_TinyTestSuite"
           key: "w3c-svg12-tinytestsuite-ubuntu-${{ steps.week.outputs.week }}"
       - name: "Install dependencies"
-        run: uv pip install -e .[dev]
+        run: uv pip install -e . --group dev
 
       - name: "Run tests for ${{ matrix.python-version }}"
         run: uv run pytest

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -45,7 +45,7 @@ jobs:
           path: "tests/samples/W3C_SVG_12_TinyTestSuite"
           key: "w3c-svg12-tinytestsuite-windows-${{ steps.week.outputs.week }}"
       - name: "Install dependencies"
-        run: uv pip install -e .[dev]
+        run: uv pip install -e . --group dev
 
       - name: "Run tests for 3.9"
         run: uv run pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
   rev: v3.21.2
   hooks:
   - id: pyupgrade
+    language_version: python3.12
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.15.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,16 +58,10 @@ svg2pdf = "svglib:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[project.optional-dependencies]
-dev = [
-    "mypy>=1.18.1",
-    "pre-commit>=4.3.0",
-    "pytest>=8.3.5",
-    "pytest-cov>=7.0.0",
-    "pytest-runner>=6.0.1",
-    "ruff>=0.13.0",
-    "tox>=4.30.2",
-]
+[dependency-groups]
+test = ["pytest>=8.3.5", "pytest-cov>=7.0.0", "pytest-runner>=6.0.1", "tox>=4.30.2"]
+lint = ["mypy>=1.18.1", "ruff>=0.13.0"]
+dev = [{include-group = "test"}, {include-group = "lint"}, "pre-commit>=4.3.0"]
 
 [tool.ruff]
 line-length = 88

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -2205,13 +2205,15 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
                     meth = getattr(ac, func)
                     setattr(shape, rlgAttr, meth(*svgAttrValues))
                 except (AttributeError, KeyError, ValueError):
+                    exc_type = sys.exc_info()[0].__name__
                     logger.debug(
-                        "applyStyleOnShape setattr({},{!r},{}(*{!r})) caused {} exception".format(
+                        "applyStyleOnShape setattr({},{!r},{}(*{!r}))"
+                        " caused {} exception".format(
                             shape.__class__.__name__,
                             rlgAttr,
                             meth.__name__,
                             svgAttrValues,
-                            sys.exc_info()[0].__name__,
+                            exc_type,
                         )
                     )
         if getattr(shape, "fillOpacity", None) is not None and shape.fillColor:

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -2205,9 +2205,15 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
                     meth = getattr(ac, func)
                     setattr(shape, rlgAttr, meth(*svgAttrValues))
                 except (AttributeError, KeyError, ValueError):
-                    logger.debug("applyStyleOnShape setattr({},{!r},{}(*{!r})) caused {} exception".format(
-                                shape.__class__.__name__, rlgAttr, meth.__name__, svgAttrValues,
-                                sys.exc_info()[0].__name__))
+                    logger.debug(
+                        "applyStyleOnShape setattr({},{!r},{}(*{!r})) caused {} exception".format(
+                            shape.__class__.__name__,
+                            rlgAttr,
+                            meth.__name__,
+                            svgAttrValues,
+                            sys.exc_info()[0].__name__,
+                        )
+                    )
         if getattr(shape, "fillOpacity", None) is not None and shape.fillColor:
             shape.fillColor.alpha = shape.fillOpacity
         if getattr(shape, "strokeWidth", None) == 0:

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,12 @@ env_list = py{39,310,311,312,313}, lint
 
 [testenv]
 package = editable
-extras = dev
+dependency_groups = dev
 commands =
     pytest {posargs}
 
 [testenv:lint]
-extras = dev
+dependency_groups = dev
 commands =
     ruff format --check .
     ruff check .


### PR DESCRIPTION
Replaces `[project.optional-dependencies]` with `[dependency-groups]` (PEP 735), which is the modern standard for dev-only dependencies — supported by pip >= 25.1 and uv.

The flat `dev` group is split into composable `test`, `lint`, and `dev` (which includes the other two). Also updates `tox.ini` and the CI workflows to use the new mechanism.

Closes #431 — thanks @claudep for the original proposal.