### PR TITLE
Add restore-keys to CI caches, upgrade to actions/cache@v4

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -36,20 +36,23 @@ jobs:
         run: echo "week=$(date +%Y-W%V)" >> "$GITHUB_OUTPUT"
 
       - name: "Cache for wikipedia flags"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "tests/samples/wikipedia/flags"
           key: "wikipedia-flags-macos-${{ steps.week.outputs.week }}"
+          restore-keys: "wikipedia-flags-macos-"
       - name: "Cache for wikipedia symbols"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "tests/samples/wikipedia/symbols"
           key: "wikipedia-symbols-macos-${{ steps.week.outputs.week }}"
+          restore-keys: "wikipedia-symbols-macos-"
       - name: "Cache for w3c svg12 tinytestsuite"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "tests/samples/W3C_SVG_12_TinyTestSuite"
           key: "w3c-svg12-tinytestsuite-macos-${{ steps.week.outputs.week }}"
+          restore-keys: "w3c-svg12-tinytestsuite-macos-"
       - name: "Install dependencies"
         run: uv pip install -e . --group dev
 

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -33,20 +33,23 @@ jobs:
         run: echo "week=$(date +%Y-W%V)" >> "$GITHUB_OUTPUT"
 
       - name: "Cache for wikipedia flags"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "tests/samples/wikipedia/flags"
           key: "wikipedia-flags-ubuntu-${{ steps.week.outputs.week }}"
+          restore-keys: "wikipedia-flags-ubuntu-"
       - name: "Cache for wikipedia symbols"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "tests/samples/wikipedia/symbols"
           key: "wikipedia-symbols-ubuntu-${{ steps.week.outputs.week }}"
+          restore-keys: "wikipedia-symbols-ubuntu-"
       - name: "Cache for w3c svg12 tinytestsuite"
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: "tests/samples/W3C_SVG_12_TinyTestSuite"
           key: "w3c-svg12-tinytestsuite-ubuntu-${{ steps.week.outputs.week }}"
+          restore-keys: "w3c-svg12-tinytestsuite-ubuntu-"
       - name: "Install dependencies"
         run: uv pip install -e . --group dev
 


### PR DESCRIPTION
Without `restore-keys`, the weekly cache key (`wikipedia-flags-ubuntu-2026-W16`) misses every Monday, forcing a full re-download of ~200 flag SVGs across all matrix jobs.

Adding a prefix-based `restore-keys` makes GitHub Actions fall back to the previous week's cache on a miss. Since Wikipedia flags rarely change week-to-week, tests find nearly everything already on disk and download nothing new — significantly reducing CI run time.

Also upgrades `actions/cache@v3` → `@v4` in the same pass.