### PR TITLE
Make bitmap rendering backend optional

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -15,14 +15,6 @@ jobs:
     steps:
       - uses: "actions/checkout@v4"
 
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@main
-
-      - name: Setup Cairo
-        run: |
-          brew install cairo pkg-config libxml2 libxslt jpeg
-
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - uses: "actions/checkout@v4"
 
+      - name: Setup native build dependencies
+        run: |
+          sudo apt-get update && \
+          sudo apt-get install -y libxml2-dev libxslt1-dev libjpeg-dev
+
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -15,11 +15,6 @@ jobs:
     steps:
       - uses: "actions/checkout@v4"
 
-      - name: Setup Cairo
-        run: |
-          sudo apt-get update && \
-          sudo apt-get install -y libcairo2-dev libffi-dev pkg-config libxml2-dev libxslt1-dev libjpeg-dev
-
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
@@ -54,4 +49,51 @@ jobs:
         run: uv pip install -e . --group dev
 
       - name: "Run tests for ${{ matrix.python-version }}"
+        run: uv run pytest
+
+  bitmap-tests:
+    name: "Bitmap tests on Ubuntu"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+
+      - name: Setup Cairo
+        run: |
+          sudo apt-get update && \
+          sudo apt-get install -y libcairo2-dev libffi-dev pkg-config libxml2-dev libxslt1-dev libjpeg-dev
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.13"
+
+      - name: Create Virtual Environment
+        run: uv venv
+
+      - name: "Get current week"
+        id: week
+        run: echo "week=$(date +%Y-W%V)" >> "$GITHUB_OUTPUT"
+
+      - name: "Cache for wikipedia flags"
+        uses: actions/cache@v4
+        with:
+          path: "tests/samples/wikipedia/flags"
+          key: "wikipedia-flags-ubuntu-bitmaps-${{ steps.week.outputs.week }}"
+          restore-keys: "wikipedia-flags-ubuntu-"
+      - name: "Cache for wikipedia symbols"
+        uses: actions/cache@v4
+        with:
+          path: "tests/samples/wikipedia/symbols"
+          key: "wikipedia-symbols-ubuntu-bitmaps-${{ steps.week.outputs.week }}"
+          restore-keys: "wikipedia-symbols-ubuntu-"
+      - name: "Cache for w3c svg12 tinytestsuite"
+        uses: actions/cache@v4
+        with:
+          path: "tests/samples/W3C_SVG_12_TinyTestSuite"
+          key: "w3c-svg12-tinytestsuite-ubuntu-bitmaps-${{ steps.week.outputs.week }}"
+          restore-keys: "w3c-svg12-tinytestsuite-ubuntu-"
+      - name: "Install dependencies"
+        run: uv pip install -e ".[bitmaps]" --group dev
+
+      - name: "Run bitmap tests"
         run: uv run pytest

--- a/.github/workflows/ci-windows-manual.yml
+++ b/.github/workflows/ci-windows-manual.yml
@@ -1,0 +1,47 @@
+name: Run Tests on Windows (Manual)
+on:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: "Python 3.13 on Windows"
+    runs-on: "windows-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.13"
+
+      - name: Create Virtual Environment
+        run: uv venv
+
+      - name: "Get current week"
+        id: week
+        run: echo "week=$(Get-Date -UFormat '%Y-W%V')" >> "$env:GITHUB_OUTPUT"
+        shell: pwsh
+
+      - name: "Cache for wikipedia flags"
+        uses: actions/cache@v4
+        with:
+          path: "tests/samples/wikipedia/flags"
+          key: "wikipedia-flags-windows-manual-${{ steps.week.outputs.week }}"
+          restore-keys: "wikipedia-flags-windows-"
+      - name: "Cache for wikipedia symbols"
+        uses: actions/cache@v4
+        with:
+          path: "tests/samples/wikipedia/symbols"
+          key: "wikipedia-symbols-windows-manual-${{ steps.week.outputs.week }}"
+          restore-keys: "wikipedia-symbols-windows-"
+      - name: "Cache for w3c svg12 tinytestsuite"
+        uses: actions/cache@v4
+        with:
+          path: "tests/samples/W3C_SVG_12_TinyTestSuite"
+          key: "w3c-svg12-tinytestsuite-windows-manual-${{ steps.week.outputs.week }}"
+          restore-keys: "w3c-svg12-tinytestsuite-windows-"
+      - name: "Install dependencies"
+        run: uv pip install -e . --group dev
+
+      - name: "Run tests"
+        run: uv run pytest

--- a/.github/workflows/ci-windows-manual.yml
+++ b/.github/workflows/ci-windows-manual.yml
@@ -1,5 +1,8 @@
 name: Run Tests on Windows (Manual)
 on:
+  push:
+    branches:
+      - optional-bitmap-backend
   workflow_dispatch:
 
 jobs:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ ChangeLog
 
 Unreleased
 ----------
+- Move ``rlpycairo`` to the ``bitmaps`` extra, so Cairo is no longer part of
+  the default installation path.
 - Add support for SVG ``linearGradient`` and ``radialGradient`` paint servers
   (#442).
 - Add support for SVG ``<switch>`` elements with conditional rendering (#441).
@@ -26,6 +28,8 @@ Unreleased
 - Add a Makefile.
 - Add publishing workflows.
 - Remove dunder constants and use importlib.metadata to get the version number.
+- Add ``rlpycairo`` as a dependency, which made Cairo part of the default
+  installation path.
 
 1.5.1 (2023-01-07)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -100,11 +100,10 @@ interactive Python session:
 .. code:: python
 
     >>> from svglib.svglib import svg2rlg
-    >>> from reportlab.graphics import renderPDF, renderPM
+    >>> from reportlab.graphics import renderPDF
     >>>
     >>> drawing = svg2rlg("file.svg")
     >>> renderPDF.drawToFile(drawing, "file.pdf")
-    >>> renderPM.drawToFile(drawing, "file.png", fmt="PNG")
 
 Note that the second parameter of ``drawToFile`` can be any
 `Python file object`_, like a ``BytesIO`` buffer if you don't want the result
@@ -157,14 +156,43 @@ Dependencies
 ``Svglib`` depends mainly on the ``reportlab`` package, which provides
 the abstractions for building complex ``Drawings`` which it can render
 into different fileformats, including PDF, EPS, SVG and various bitmaps
-ones. Other dependancies are ``lxml`` which is used in the context of SVG
+ones. Other dependencies are ``lxml`` which is used in the context of SVG
 CSS stylesheets.
 
-Previous versions of this package included a way to run `cairo` without explicit
-installation by the user; the dependency that took care of that no longer does
-this installation, and as such, the user must install `cairo` themselves. For
-installation instructions, see the official website:
-https://www.cairographics.org/download/
+PDF output does not require Cairo. SVG images embedded in input files are
+included in generated PDFs through ReportLab's PDF renderer.
+
+Bitmap output
++++++++++++++
+
+Rendering ReportLab drawings to bitmap formats such as PNG uses
+``reportlab.graphics.renderPM`` and requires a renderPM backend.
+
+The default ReportLab 4.x backend is ``rlPyCairo``::
+
+    $ pip install "svglib[bitmaps]"
+
+Depending on the platform, ``pycairo`` may also require the system Cairo
+library to be installed. For installation instructions, see the official
+website: https://www.cairographics.org/download/
+
+Alternatively, users can install ReportLab's legacy ``_renderPM`` backend::
+
+    $ pip install svglib rl-renderPM
+
+To choose a backend explicitly, set ReportLab's renderPM backend before calling
+``renderPM``:
+
+.. code:: python
+
+    from reportlab import rl_config
+    from reportlab.graphics import renderPM
+
+    rl_config.renderPMBackend = "rlPyCairo"  # default in ReportLab 4.x
+    # or:
+    rl_config.renderPMBackend = "_renderPM"
+
+    renderPM.drawToFile(drawing, "file.png", fmt="PNG")
 
 
 Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,11 @@ dependencies = [
     "cssselect2>=0.2.0",
     "lxml>=6.0.0",
     "reportlab>=4.4.3",
-    "rlpycairo>=0.4.0",
     "tinycss2>=0.6.0",
 ]
+
+[project.optional-dependencies]
+bitmaps = ["rlpycairo>=0.4.0"]
 
 [project.urls]
 Homepage = "https://github.com/deeplook/svglib"

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -33,6 +33,16 @@ from svglib import svglib
 TEST_ROOT = dirname(__file__)
 
 
+def has_renderpm_backend() -> bool:
+    """Return whether ReportLab can load a renderPM bitmap backend."""
+
+    try:
+        renderPM._getPMBackend()
+    except renderPM.RenderPMError:
+        return False
+    return True
+
+
 def found_uniconv() -> bool:
     "Do we have uniconv installed?"
 
@@ -407,6 +417,7 @@ class TestW3CSVG:
             print(f"deleting [{i}] {path}")
             os.remove(path)
 
+    @pytest.mark.skipif(not has_renderpm_backend(), reason="needs a renderPM backend")
     def test_convert_pdf_png(self):
         """
         Test converting W3C SVG files to PDF and PNG using svglib.

--- a/uv.lock
+++ b/uv.lock
@@ -811,8 +811,12 @@ dependencies = [
     { name = "cssselect2" },
     { name = "lxml" },
     { name = "reportlab" },
-    { name = "rlpycairo" },
     { name = "tinycss2" },
+]
+
+[package.optional-dependencies]
+bitmaps = [
+    { name = "rlpycairo" },
 ]
 
 [package.dev-dependencies]
@@ -841,9 +845,10 @@ requires-dist = [
     { name = "cssselect2", specifier = ">=0.2.0" },
     { name = "lxml", specifier = ">=6.0.0" },
     { name = "reportlab", specifier = ">=4.4.3" },
-    { name = "rlpycairo", specifier = ">=0.4.0" },
+    { name = "rlpycairo", marker = "extra == 'bitmaps'", specifier = ">=0.4.0" },
     { name = "tinycss2", specifier = ">=0.6.0" },
 ]
+provides-extras = ["bitmaps"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Move rlpycairo out of the default dependency set and into a new bitmaps extra.
- Update README and changelog to clarify that PDF output does not require Cairo, while renderPM bitmap output needs a backend.
- Skip only the renderPM PNG sample test when no bitmap backend is installed.
- Split CI so Ubuntu/macOS exercise the default install without Cairo, while Ubuntu bitmap tests install svglib[bitmaps].
- Add a separate Windows manual/core test workflow for this branch.

## Verification
- Local default install: 117 passed, 7 skipped.
- Local bitmaps extra install: 118 passed, 6 skipped, 1 warning.
- uv lock --check: passed.
- ruff check .: passed.
- GitHub Actions on optional-bitmap-backend: Ubuntu passed, macOS passed, Windows manual passed.