### PR TITLE
Fix bare-number/px unit inconsistency and coordinate system (2.0b1)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,21 +3,39 @@
 ChangeLog
 =========
 
-Unreleased
-----------
+2.0b1 (2026-04-29)
+------------------
+
+**Breaking change — output sizes will differ from 1.x.**
+
+svglib now correctly maps SVG user units to ReportLab points using the
+standard SVG/CSS conversion factor: 1 px = 0.75 pt (96 dpi).  Previous
+releases treated 1 user unit as 1 pt, which is 33 % too large.  Any SVG
+whose ``width``/``height`` or ``viewBox`` uses user units or ``px`` will
+produce a PDF that is 75 % of its previous linear dimensions (same
+proportions, correct physical size).
+
+*Migration* — if you need to preserve the old apparent size, scale the
+returned ``Drawing`` object before use::
+
+    from svglib.svglib import svg2rlg
+
+    drawing = svg2rlg("file.svg")
+    # Restore 1.x dimensions (1 user unit → 1 pt, non-spec):
+    factor = 4 / 3          # 1 / 0.75
+    drawing.width  *= factor
+    drawing.height *= factor
+    drawing.scale(factor, factor)
+
 - Move ``rlpycairo`` to the ``bitmaps`` extra, so Cairo is no longer part of
   the default installation path.
 - Fix inconsistent unit handling: bare numbers and ``px`` units now produce
   identical output, as required by the SVG spec (§5.9.2). ``convertLength``
   now returns user units (px) instead of ReportLab points; a new
   ``convertLengthToPt`` helper is used where absolute point values are needed
-  (font sizes, canvas dimensions). **Output sizes will change** for SVGs that
-  mix bare-number and ``px`` lengths, or that use physical units (``cm``,
-  ``mm``, ``in``, ``pt``, ``pc``) without a ``viewBox`` — the rendered PDF
-  will now match browser output rather than the previous (incorrect) scaling
-  (#439).
+  (font sizes, canvas dimensions) (#439).
 - Fix SVGs with a ``viewBox`` but no explicit ``width``/``height``: the
-  viewport scale now defaults to PX_TO_PT (0.75) instead of 1, preventing
+  viewport scale now defaults to ``PX_TO_PT`` (0.75) instead of 1, preventing
   content from being cropped.
 - Add support for SVG ``linearGradient`` and ``radialGradient`` paint servers
   (#442).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,18 @@ Unreleased
 ----------
 - Move ``rlpycairo`` to the ``bitmaps`` extra, so Cairo is no longer part of
   the default installation path.
+- Fix inconsistent unit handling: bare numbers and ``px`` units now produce
+  identical output, as required by the SVG spec (§5.9.2). ``convertLength``
+  now returns user units (px) instead of ReportLab points; a new
+  ``convertLengthToPt`` helper is used where absolute point values are needed
+  (font sizes, canvas dimensions). **Output sizes will change** for SVGs that
+  mix bare-number and ``px`` lengths, or that use physical units (``cm``,
+  ``mm``, ``in``, ``pt``, ``pc``) without a ``viewBox`` — the rendered PDF
+  will now match browser output rather than the previous (incorrect) scaling
+  (#439).
+- Fix SVGs with a ``viewBox`` but no explicit ``width``/``height``: the
+  viewport scale now defaults to PX_TO_PT (0.75) instead of 1, preventing
+  content from being cropped.
 - Add support for SVG ``linearGradient`` and ``radialGradient`` paint servers
   (#442).
 - Add support for SVG ``<switch>`` elements with conditional rendering (#441).

--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,64 @@ the system command-line. Here is the output from ``svg2pdf -h``::
         https://github.com/deeplook/svglib
 
 
+Units and output sizes
+----------------------
+
+SVG is anchored to a **96 dpi** coordinate system: one user unit (bare
+number or ``px``) equals one CSS pixel, which is 1/96 of an inch.
+ReportLab works in **points** (1 pt = 1/72 inch).  The conversion
+factor is ``1 px = 0.75 pt``.
+
+The ``Drawing`` object returned by ``svg2rlg`` always has its
+``width`` and ``height`` expressed in ReportLab points.  The table
+below shows what you get for common unit choices on the root ``<svg>``
+element:
+
+======================  ============================  ==================
+SVG ``width``           ``Drawing.width`` (pt)        Physical width
+======================  ============================  ==================
+``width="96"``          72 pt                         1 inch
+``width="96px"``        72 pt (same as bare)          1 inch
+``width="72pt"``        72 pt                         1 inch
+``width="25.4mm"``      72 pt                         1 inch
+``width="1in"``         72 pt                         1 inch
+======================  ============================  ==================
+
+The physical size is the same in every row — the unit only affects
+which number appears in the file.
+
+**Font sizes** follow the same rule.  ``font-size="16"`` (bare or
+``px``) produces a 12 pt font in the PDF (16 × 0.75).  Use
+``font-size="12pt"`` when you need to specify a precise typographic
+size directly.
+
+**Choosing units**
+
+- *Web-first SVGs*: use bare numbers throughout and a ``viewBox``.
+  The browser renders at 96 dpi; svglib scales to 72 dpi points.
+  Physical dimensions are preserved in the PDF.
+- *Print at an exact physical size*: declare ``width``/``height`` in
+  ``mm``, ``cm``, or ``in`` on the ``<svg>`` element and use a
+  matching ``viewBox``.  Both screen and print will show the declared
+  physical size.
+- *Control exact PDF point dimensions*: use ``pt`` units on
+  ``width``/``height``; the numeric value is preserved in the Drawing.
+
+**Adjusting the output size at render time**
+
+If you need to rescale the returned Drawing (e.g. to fit a fixed page
+size or restore the pre-2.0 behaviour), scale the Drawing object
+directly:
+
+.. code:: python
+
+    drawing = svg2rlg("file.svg")
+    factor = 4 / 3   # restore 1.x size (1 user unit → 1 pt, non-spec)
+    drawing.width  *= factor
+    drawing.height *= factor
+    drawing.scale(factor, factor)
+
+
 Dependencies
 ------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svglib"
-version = "1.6.0"
+version = "2.0b1"
 description = "A pure-Python library for reading and converting SVG"
 readme = "README.rst"
 authors = [{ name = "Dinu Gherman" }]
@@ -12,7 +12,7 @@ keywords = [
     "graphics",
 ]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
+    "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: End Users/Desktop",
     "Intended Audience :: Developers",

--- a/src/svglib/fonts.py
+++ b/src/svglib/fonts.py
@@ -39,7 +39,7 @@ STANDARD_FONT_NAMES = (
 DEFAULT_FONT_NAME = "Helvetica"
 DEFAULT_FONT_WEIGHT = "normal"
 DEFAULT_FONT_STYLE = "normal"
-DEFAULT_FONT_SIZE = 12
+DEFAULT_FONT_SIZE = 16  # 16 user units (px); equals 12 pt after px→pt conversion
 
 
 class FontMap:

--- a/src/svglib/fonts.py
+++ b/src/svglib/fonts.py
@@ -39,7 +39,7 @@ STANDARD_FONT_NAMES = (
 DEFAULT_FONT_NAME = "Helvetica"
 DEFAULT_FONT_WEIGHT = "normal"
 DEFAULT_FONT_STYLE = "normal"
-DEFAULT_FONT_SIZE = 16  # 16 user units (px); equals 12 pt after px→pt conversion
+DEFAULT_FONT_SIZE = 12  # points (CSS/SVG default: 12 pt = 16 px)
 
 
 class FontMap:

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -484,11 +484,11 @@ class Svg2RlgAttributeConverter(AttributeConverter):
     def convertLength(
         self,
         svgAttr: str,
-        em_base: float = DEFAULT_FONT_SIZE,
+        em_base: float = DEFAULT_FONT_SIZE / PX_TO_PT,
         attr_name: Optional[str] = None,
         default: float = 0.0,
     ) -> Union[float, List[float]]:
-        """Convert an SVG length string to points.
+        """Convert an SVG length string to user units (px).
 
         Args:
             svgAttr: The SVG length string (e.g., "10px", "5em").
@@ -574,7 +574,7 @@ class Svg2RlgAttributeConverter(AttributeConverter):
     def convertLengthToPt(
         self,
         svgAttr: str,
-        em_base: float = DEFAULT_FONT_SIZE,
+        em_base: float = DEFAULT_FONT_SIZE / PX_TO_PT,
         attr_name: Optional[str] = None,
         default: float = 0.0,
     ) -> Union[float, List[float]]:
@@ -1519,7 +1519,6 @@ class SvgRenderer:
             # Apply only the 'reverse' y-scaling (PDF 0,0 is bottom left)
             group.scale(1, -1)
         elif view_box:
-            x_scale, y_scale = 1, 1
             width, height = self.shape_converter.convert_length_attrs(
                 node, "width", "height", defaults=(None,) * 2
             )
@@ -1536,11 +1535,15 @@ class SvgRenderer:
                     width = _saved_box.width
                 if height is None:
                     height = _saved_box.height
+            # Fall back to viewBox dimensions (user units) when no explicit size.
+            # render() does the same, so Drawing size = viewBox × PX_TO_PT.
+            if width is None:
+                width = view_box.width
+            if height is None:
+                height = view_box.height
             # canvas is in pts; view_box is in user units — scale converts user→pt
-            if height is not None:
-                y_scale = (height * PX_TO_PT) / view_box.height
-            if width is not None:
-                x_scale = (width * PX_TO_PT) / view_box.width
+            x_scale = (width * PX_TO_PT) / view_box.width if view_box.width else 1
+            y_scale = (height * PX_TO_PT) / view_box.height if view_box.height else 1
             group.scale(x_scale, y_scale * (-1 if outermost else 1))
 
         return group
@@ -1724,7 +1727,7 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
         self,
         node: Any,
         *attrs: str,
-        em_base: float = DEFAULT_FONT_SIZE,
+        em_base: float = DEFAULT_FONT_SIZE / PX_TO_PT,
         **kwargs: Any,
     ) -> List[float]:
         """Convert a list of length attributes from a node.
@@ -1845,7 +1848,7 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
         fw = attrConv.findAttr(node, "font-weight") or DEFAULT_FONT_WEIGHT
         fstyle = attrConv.findAttr(node, "font-style") or DEFAULT_FONT_STYLE
         ff = attrConv.convertFontFamily(ff, fw, fstyle)
-        fs = attrConv.findAttr(node, "font-size") or str(DEFAULT_FONT_SIZE)
+        fs = attrConv.findAttr(node, "font-size") or f"{DEFAULT_FONT_SIZE}pt"
         fs = attrConv.convertLength(fs)  # type: ignore  (user units, used as em_base)
         fs_pt = fs * PX_TO_PT  # absolute points for ReportLab font metrics
         x: List[float]
@@ -2202,7 +2205,12 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
                 "convertFontFamily",
                 [DEFAULT_FONT_NAME, DEFAULT_FONT_WEIGHT, DEFAULT_FONT_STYLE],
             ),
-            (["font-size"], "fontSize", "convertLengthToPt", [str(DEFAULT_FONT_SIZE)]),
+            (
+                ["font-size"],
+                "fontSize",
+                "convertLengthToPt",
+                [f"{DEFAULT_FONT_SIZE}pt"],
+            ),
             (["text-anchor"], "textAnchor", "id", ["start"]),
         )
 

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -53,7 +53,7 @@ from reportlab.graphics.shapes import (
     _renderPath,
 )
 from reportlab.lib import colors
-from reportlab.lib.units import pica, toLength
+from reportlab.lib.units import toLength
 from reportlab.pdfbase.pdfmetrics import stringWidth
 from reportlab.pdfgen.canvas import FILL_EVEN_ODD, FILL_NON_ZERO
 from reportlab.pdfgen.pdfimages import PDFImage
@@ -89,6 +89,9 @@ from .utils import (
     convert_quadratic_to_cubic_path,
     normalise_svg_path,
 )
+
+# SVG user units are px; ReportLab works in points.  1 px = 0.75 pt (96 dpi / 72 dpi).
+PX_TO_PT = 0.75
 
 
 def _convert_palette_to_rgba(image: PILImage.Image) -> PILImage.Image:
@@ -536,13 +539,16 @@ class Svg2RlgAttributeConverter(AttributeConverter):
                 return float(text[:-1])
             return float(text[:-1]) / 100 * full
         elif text.endswith("pc"):
-            return float(text[:-2]) * pica
+            # 1 pc = 12 pt = 16 px user units
+            return float(text[:-2]) * 16
         elif text.endswith("pt"):
-            return float(text[:-2])
+            # 1 pt = 1/72 in = 96/72 px user units
+            return float(text[:-2]) * (96 / 72)
         elif text.endswith("em"):
             return float(text[:-2]) * em_base
         elif text.endswith("px"):
-            return float(text[:-2]) * 0.75
+            # px are user units (1:1)
+            return float(text[:-2])
         elif text.endswith("ex"):
             # The x-height of the text must be assumed to be 0.5em tall when the
             # text cannot be measured.
@@ -553,13 +559,32 @@ class Svg2RlgAttributeConverter(AttributeConverter):
             return float(text[:-2]) * em_base / 2
 
         text = text.strip()
-        length = toLength(text)  # this does the default measurements such as mm and cm
-
-        return length
+        try:
+            # Bare numbers are user units (= px, SVG spec §5.9.2) — return as-is.
+            return float(text)
+        except ValueError:
+            pass
+        # toLength handles mm, cm, in, etc. and returns points; convert to user units.
+        return toLength(text) / PX_TO_PT
 
     def convertLengthList(self, svgAttr: str) -> List[Union[float, List[float]]]:
         """Convert a space-separated list of lengths into a list of floats."""
         return [self.convertLength(a) for a in self.split_attr_list(svgAttr)]
+
+    def convertLengthToPt(
+        self,
+        svgAttr: str,
+        em_base: float = DEFAULT_FONT_SIZE,
+        attr_name: Optional[str] = None,
+        default: float = 0.0,
+    ) -> Union[float, List[float]]:
+        """Convert an SVG length string to points (user units × PX_TO_PT)."""
+        result = self.convertLength(
+            svgAttr, em_base=em_base, attr_name=attr_name, default=default
+        )
+        if isinstance(result, list):
+            return [v * PX_TO_PT for v in result]
+        return result * PX_TO_PT
 
     def convertOpacity(self, svgAttr: str) -> float:
         """Convert an opacity string to a float."""
@@ -962,7 +987,7 @@ class SvgRenderer:
         width, height = self.shape_converter.convert_length_attrs(
             svg_node, "width", "height", defaults=(view_box.width, view_box.height)
         )
-        drawing = Drawing(width, height)
+        drawing = Drawing(width * PX_TO_PT, height * PX_TO_PT)
         drawing.add(main_group)
         return drawing
 
@@ -1442,8 +1467,10 @@ class SvgRenderer:
         """
         view_box = svg_node.getAttribute("viewBox")
         if view_box:
-            view_box = self.attrConverter.convertLengthList(view_box)  # type: ignore
-            return Box(*view_box)
+            # viewBox defines a unitless user-coordinate space (SVG spec §8.1).
+            # Parse as raw floats — never apply unit conversion here.
+            values = [float(v) for v in view_box.replace(",", " ").split()]
+            return Box(*values)
         if default_box:
             width, height = map(svg_node.getAttribute, ("width", "height"))
             width, height = map(self.attrConverter.convertLength, (width, height))  # type: ignore
@@ -1509,10 +1536,11 @@ class SvgRenderer:
                     width = _saved_box.width
                 if height is None:
                     height = _saved_box.height
-            if height is not None and view_box.height != height:
-                y_scale = height / view_box.height
-            if width is not None and view_box.width != width:
-                x_scale = width / view_box.width
+            # canvas is in pts; view_box is in user units — scale converts user→pt
+            if height is not None:
+                y_scale = (height * PX_TO_PT) / view_box.height
+            if width is not None:
+                x_scale = (width * PX_TO_PT) / view_box.width
             group.scale(x_scale, y_scale * (-1 if outermost else 1))
 
         return group
@@ -1818,7 +1846,8 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
         fstyle = attrConv.findAttr(node, "font-style") or DEFAULT_FONT_STYLE
         ff = attrConv.convertFontFamily(ff, fw, fstyle)
         fs = attrConv.findAttr(node, "font-size") or str(DEFAULT_FONT_SIZE)
-        fs = attrConv.convertLength(fs)  # type: ignore
+        fs = attrConv.convertLength(fs)  # type: ignore  (user units, used as em_base)
+        fs_pt = fs * PX_TO_PT  # absolute points for ReportLab font metrics
         x: List[float]
         y: List[float]
         x, y = self.convert_length_attrs(node, "x", "y", em_base=fs)  # type: ignore
@@ -1852,7 +1881,7 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
             else:
                 baseLineShift = attrConv.convertLength(baseLineShift, em_base=fs)  # type: ignore
 
-            frag_lengths.append(stringWidth(text, ff, fs))  # type: ignore
+            frag_lengths.append(stringWidth(text, ff, fs_pt))  # type: ignore
 
             # When x, y, dx, or dy is a list, we calculate position for each char of
             # text.
@@ -1878,7 +1907,7 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
                     if char_dy is None:
                         char_dy = 0
                     new_x = char_dx + (
-                        last_x + stringWidth(last_char, ff, fs)
+                        last_x + stringWidth(last_char, ff, fs_pt)
                         if char_x is None
                         else char_x
                     )
@@ -2173,7 +2202,7 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
                 "convertFontFamily",
                 [DEFAULT_FONT_NAME, DEFAULT_FONT_WEIGHT, DEFAULT_FONT_STYLE],
             ),
-            (["font-size"], "fontSize", "convertLength", [str(DEFAULT_FONT_SIZE)]),
+            (["font-size"], "fontSize", "convertLengthToPt", [str(DEFAULT_FONT_SIZE)]),
             (["text-anchor"], "textAnchor", "id", ["start"]),
         )
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -405,6 +405,40 @@ class TestLengthAttrConverter:
         assert len(failed) == 0
         assert ac.convertLength("1.5em", em_base=16.5) == 24.75
 
+    def test_bare_number_equals_px(self):
+        "Bare numbers and px units must produce identical lengths (issue #439)."
+        ac = svglib.Svg2RlgAttributeConverter()
+        # In user-unit space, "N" and "Npx" are the same (SVG spec §5.9.2).
+        assert ac.convertLength("13") == ac.convertLength("13px")
+        assert ac.convertLength("100") == ac.convertLength("100px")
+        assert ac.convertLength("0.5") == ac.convertLength("0.5px")
+        # convertLengthToPt must be consistent too (used for font-size).
+        assert ac.convertLengthToPt("13") == ac.convertLengthToPt("13px")
+
+    def test_font_size_bare_number_vs_px(self):
+        "font-size='N' and font-size='Npx' must produce the same fontSize (issue #439)."
+        svg_tmpl = """<svg xmlns="http://www.w3.org/2000/svg"
+                          width="200" height="50" viewBox="0 0 200 50">
+            <text font-size="{fs}">x</text>
+        </svg>"""
+        import io
+
+        from lxml import etree
+
+        def font_size_for(fs_attr):
+            root = etree.parse(
+                io.BytesIO(svg_tmpl.format(fs=fs_attr).encode())
+            ).getroot()
+            drawing = svglib.SvgRenderer("").render(root)
+            # Walk into the drawing to find the first String object.
+            group = drawing.contents[0]
+            while hasattr(group, "contents"):
+                group = group.contents[0]
+            return group.fontSize
+
+        assert font_size_for("13") == font_size_for("13px")
+        assert font_size_for("24") == font_size_for("24px")
+
     def test_percentage_conversion(self):
         "Test percentage length attribute conversion."
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -389,15 +389,15 @@ class TestLengthAttrConverter:
             ("-3.16", -3.16),
             ("-1e-2", -0.01),
             ("1e-5", 1e-5),
-            ("1e1cm", 10 * cm),
-            ("1e1in", 10 * inch),
-            ("-8e-2cm", (-8e-2) * cm),
-            ("20px", 20 * 0.75),
-            ("20pt", 20),
-            ("1.5em", 12 * 1.5),
-            ("10.5mm", 10.5 * (cm * 0.1)),
+            ("1e1cm", 10 * cm / 0.75),
+            ("1e1in", 10 * inch / 0.75),
+            ("-8e-2cm", (-8e-2) * cm / 0.75),
+            ("20px", 20),
+            ("20pt", 20 * (96 / 72)),
+            ("1.5em", 16 * 1.5),
+            ("10.5mm", 10.5 * (cm * 0.1) / 0.75),
             ("3, 5 -7", [3, 5, -7]),
-            ("2pt  12pt", [2, 12]),
+            ("2pt  12pt", [2 * (96 / 72), 12 * (96 / 72)]),
             ("10 20 30", [10.0, 20.0, 30.0]),
         )
         ac = svglib.Svg2RlgAttributeConverter()
@@ -420,7 +420,7 @@ class TestLengthAttrConverter:
         "Test length list attribute conversion."
 
         mapping = (
-            (" 5cm 5in", [5 * cm, 5 * inch]),
+            (" 5cm 5in", [5 * cm / 0.75, 5 * inch / 0.75]),
             (" 5, 5", [5, 5]),
         )
         ac = svglib.Svg2RlgAttributeConverter()
@@ -1252,7 +1252,7 @@ class TestViewBox:
         """
         )
         # Main group coordinates are translated to match the viewBox origin
-        assert drawing.contents[0].transform == (10, 0, 0, -10, 600.0, 400.0)
+        assert drawing.contents[0].transform == (7.5, 0.0, 0.0, -7.5, 450.0, 300.0)
 
     def test_percent_width_height(self):
         drawing = drawing_from_svg(
@@ -1267,7 +1267,7 @@ class TestViewBox:
             </svg>
         """
         )
-        assert (drawing.width, drawing.height) == (480, 360)
+        assert (drawing.width, drawing.height) == (360.0, 270.0)
 
     def test_no_width_height(self):
         drawing = drawing_from_svg(
@@ -1281,7 +1281,7 @@ class TestViewBox:
             </svg>
         """
         )
-        assert (drawing.width, drawing.height) == (480, 360)
+        assert (drawing.width, drawing.height) == (360.0, 270.0)
 
 
 class TestEmbedded:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1395,11 +1395,12 @@ class TestEmbedded:
         )
         nested_group = drawing.contents[0].contents[0]
         xmin, ymin, xmax, ymax = nested_group.getBounds()
-        # Parent viewport is 200x200, inner viewBox is 50x50, so the rect
-        # should be rendered at the full 200x200 — not 50x50, which is what
-        # happens without the fallback.
-        assert xmax - xmin == 200
-        assert ymax - ymin == 200
+        # Parent viewport is 200x200px = 150x150pt (px→pt at 0.75). The inner
+        # SVG inherits the parent slot, so the rect fills 150×150pt — not
+        # 50×50 (viewBox units without scaling), which is what happens without
+        # the fallback.
+        assert xmax - xmin == pytest.approx(150)
+        assert ymax - ymin == pytest.approx(150)
 
     def test_png_in_svg_file_like(self):
         drawing = drawing_from_svg(

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -506,7 +506,9 @@ class TestOtherFiles:
         unit_names = ["px", "pt", "mm", "ex", "ch", "em", "pc", "cm"]
         lengths_by_name = dict(zip(unit_names, unit_widths))
         assert lengths_by_name["px"] == lengths_by_name["pt"] * 0.75
-        assert lengths_by_name["em"] == svglib.DEFAULT_FONT_SIZE  # 1 em == font size
+        assert (
+            lengths_by_name["em"] == svglib.DEFAULT_FONT_SIZE / svglib.PX_TO_PT
+        )  # 1 em == font size in user units
         assert lengths_by_name["ex"] == lengths_by_name["em"] / 2
         assert lengths_by_name["ch"] == lengths_by_name["ex"]
 

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,239 @@
+"""Tests for SVG length-unit handling and output dimensions.
+
+SVG lives in a 96 dpi world (1 user unit = 1 CSS px = 1/96 inch).
+ReportLab works in points (1 pt = 1/72 inch).
+The bridge: 1 px = 0.75 pt  (PX_TO_PT).
+
+These tests document and protect the expected behaviour so that users
+can predict what they will get when they convert an SVG to a PDF or
+bitmap with svglib:
+
+  - Drawing.width / Drawing.height are always in ReportLab points.
+  - Bare numbers and ``px`` units on the <svg> element give the same
+    Drawing size (both = value × 0.75 pt).
+  - Explicit ``pt`` units are passed through unchanged (value pt).
+  - Physical units (``mm``, ``cm``, ``in``) produce the correct point
+    size for the declared physical measurement.
+  - Font sizes follow the same rules: a bare-number/px font-size of N
+    results in a ReportLab fontSize of N × 0.75 pt.
+
+Run with: uv run pytest -v tests/test_units.py
+"""
+
+import io
+import math
+
+from lxml import etree
+from reportlab.graphics.shapes import String
+
+from svglib.svglib import PX_TO_PT, SvgRenderer
+from tests.utils import drawing_from_svg
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _drawing(width_attr, height_attr, extra_attrs=""):
+    """Return a Drawing for an SVG whose root element has the given
+    width / height attribute strings (e.g. ``'100'``, ``'100px'``,
+    ``'72pt'``, ``'25.4mm'``).
+    """
+    svg = f"""<?xml version="1.0"?>
+    <svg xmlns="http://www.w3.org/2000/svg"
+         width="{width_attr}" height="{height_attr}" {extra_attrs}>
+        <rect x="0" y="0" width="10" height="10" fill="red"/>
+    </svg>"""
+    return drawing_from_svg(svg)
+
+
+def _font_size_pt(fs_attr):
+    """Return the ReportLab fontSize (in pt) for a <text> element whose
+    font-size attribute is *fs_attr*.
+    """
+    svg = f"""<?xml version="1.0"?>
+    <svg xmlns="http://www.w3.org/2000/svg"
+         width="200" height="50" viewBox="0 0 200 50">
+        <text font-size="{fs_attr}">x</text>
+    </svg>"""
+    root = etree.parse(io.BytesIO(svg.encode())).getroot()
+    drawing = SvgRenderer("").render(root)
+    # Walk into the drawing tree to find the first String shape.
+    node = drawing.contents[0]
+    while hasattr(node, "contents"):
+        node = node.contents[0]
+    assert isinstance(node, String), f"Expected String, got {type(node)}"
+    return node.fontSize
+
+
+# ---------------------------------------------------------------------------
+# Drawing dimensions — user units / px
+# ---------------------------------------------------------------------------
+
+
+class TestDrawingDimensionsUserUnits:
+    """Bare numbers and ``px`` on the root <svg> element.
+
+    SVG spec: bare numbers are user units; 1 user unit = 1 CSS px.
+    svglib converts to pt: Drawing size = value × PX_TO_PT.
+    """
+
+    def test_bare_number_width(self):
+        """width="100" (bare) → Drawing.width == 75 pt."""
+        d = _drawing("100", "50")
+        assert math.isclose(d.width, 100 * PX_TO_PT)
+
+    def test_bare_number_height(self):
+        """height="50" (bare) → Drawing.height == 37.5 pt."""
+        d = _drawing("100", "50")
+        assert math.isclose(d.height, 50 * PX_TO_PT)
+
+    def test_px_width(self):
+        """width="100px" → same Drawing.width as bare "100"."""
+        d_bare = _drawing("100", "50")
+        d_px = _drawing("100px", "50px")
+        assert math.isclose(d_px.width, d_bare.width)
+        assert math.isclose(d_px.height, d_bare.height)
+
+    def test_bare_and_px_are_identical(self):
+        """Drawing dimensions for bare-number and px must agree (issue #439)."""
+        for val in (50, 96, 200, 480):
+            d_bare = _drawing(str(val), str(val))
+            d_px = _drawing(f"{val}px", f"{val}px")
+            assert math.isclose(d_bare.width, d_px.width), f"width mismatch for {val}"
+            assert math.isclose(d_bare.height, d_px.height), (
+                f"height mismatch for {val}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Drawing dimensions — point units
+# ---------------------------------------------------------------------------
+
+
+class TestDrawingDimensionsPt:
+    """Explicit ``pt`` units on the root <svg> element.
+
+    ``pt`` in SVG is an absolute unit (1/72 inch).  After the round-trip
+    through user units and back to pt, the numeric value must be
+    preserved: width="100pt" → Drawing.width == 100 pt.
+    """
+
+    def test_pt_width_preserved(self):
+        """width="72pt" → Drawing.width == 72 pt."""
+        d = _drawing("72pt", "72pt")
+        assert math.isclose(d.width, 72.0, rel_tol=1e-4)
+
+    def test_pt_height_preserved(self):
+        """height="36pt" → Drawing.height == 36 pt."""
+        d = _drawing("100pt", "36pt")
+        assert math.isclose(d.height, 36.0, rel_tol=1e-4)
+
+    def test_pt_differs_from_bare(self):
+        """width="100pt" must give a larger Drawing than width="100" (bare px)."""
+        d_pt = _drawing("100pt", "100pt")
+        d_bare = _drawing("100", "100")
+        # 100 pt > 75 pt (100 × 0.75)
+        assert d_pt.width > d_bare.width
+
+
+# ---------------------------------------------------------------------------
+# Drawing dimensions — physical units
+# ---------------------------------------------------------------------------
+
+
+class TestDrawingDimensionsPhysical:
+    """mm, cm, in on the root <svg> element.
+
+    Physical units must round-trip to the correct point size:
+      1 in  = 72 pt
+      25.4 mm = 1 in = 72 pt
+      2.54 cm = 1 in = 72 pt
+    """
+
+    def test_one_inch_width(self):
+        """width="1in" → Drawing.width == 72 pt."""
+        d = _drawing("1in", "1in")
+        assert math.isclose(d.width, 72.0, rel_tol=1e-4)
+
+    def test_25_4mm_equals_one_inch(self):
+        """width="25.4mm" → Drawing.width == 72 pt (1 inch)."""
+        d = _drawing("25.4mm", "25.4mm")
+        assert math.isclose(d.width, 72.0, rel_tol=1e-3)
+
+    def test_2_54cm_equals_one_inch(self):
+        """width="2.54cm" → Drawing.width == 72 pt (1 inch)."""
+        d = _drawing("2.54cm", "2.54cm")
+        assert math.isclose(d.width, 72.0, rel_tol=1e-3)
+
+    def test_mm_and_in_agree(self):
+        """25.4 mm and 1 in must produce the same Drawing size."""
+        d_mm = _drawing("25.4mm", "25.4mm")
+        d_in = _drawing("1in", "1in")
+        assert math.isclose(d_mm.width, d_in.width, rel_tol=1e-4)
+
+    def test_96px_equals_one_inch(self):
+        """96 CSS px == 1 inch; Drawing.width for width="96" == 72 pt."""
+        d = _drawing("96", "96")
+        assert math.isclose(d.width, 72.0, rel_tol=1e-4)
+
+    def test_96px_and_1in_agree(self):
+        """width="96" and width="1in" must produce the same Drawing size."""
+        d_px = _drawing("96", "96")
+        d_in = _drawing("1in", "1in")
+        assert math.isclose(d_px.width, d_in.width, rel_tol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Font sizes
+# ---------------------------------------------------------------------------
+
+
+class TestFontSizeUnits:
+    """Font-size unit handling.
+
+    Font sizes are lengths like any other in SVG.  They are parsed to
+    user units (px) and then multiplied by PX_TO_PT for ReportLab.
+
+    Key fact: font-size="16" (bare/px) → 12 pt in the PDF,
+              font-size="12pt"          → 12 pt in the PDF.
+    """
+
+    def test_bare_font_size_scaled_to_pt(self):
+        """font-size="16" (bare) → fontSize == 12 pt in ReportLab."""
+        assert math.isclose(_font_size_pt("16"), 16 * PX_TO_PT)
+
+    def test_px_font_size_scaled_to_pt(self):
+        """font-size="16px" → fontSize == 12 pt in ReportLab."""
+        assert math.isclose(_font_size_pt("16px"), 16 * PX_TO_PT)
+
+    def test_pt_font_size_preserved(self):
+        """font-size="12pt" → fontSize == 12 pt (no scaling surprise)."""
+        assert math.isclose(_font_size_pt("12pt"), 12.0, rel_tol=1e-4)
+
+    def test_bare_and_px_font_size_identical(self):
+        """font-size="N" and font-size="Npx" must produce identical fontSize."""
+        for n in (10, 13, 16, 24):
+            assert math.isclose(
+                _font_size_pt(str(n)),
+                _font_size_pt(f"{n}px"),
+            ), f"font-size mismatch for {n}"
+
+    def test_16px_equals_12pt(self):
+        """font-size="16px" and font-size="12pt" must produce the same fontSize.
+
+        16 CSS px × 0.75 = 12 pt — both specify the same physical text size.
+        """
+        assert math.isclose(
+            _font_size_pt("16px"),
+            _font_size_pt("12pt"),
+            rel_tol=1e-4,
+        )
+
+    def test_96px_equals_72pt_font(self):
+        """font-size="96px" and font-size="72pt" — one inch of text."""
+        assert math.isclose(
+            _font_size_pt("96px"),
+            _font_size_pt("72pt"),
+            rel_tol=1e-4,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -805,7 +805,7 @@ wheels = [
 
 [[package]]
 name = "svglib"
-version = "1.6.0"
+version = "2.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "cssselect2" },


### PR DESCRIPTION
Fixes #439.

## Summary

SVG spec §5.9.2 defines 1 user unit = 1 px = 0.75 pt (at 96 dpi). Previous
releases treated 1 user unit as 1 pt, causing `font-size="13"` and
`font-size="13px"` to render at different sizes, and all output to be 33%
larger than a browser would produce.

## Changes

- `convertLength` now returns **user units (px)** instead of ReportLab points.
- New `convertLengthToPt` helper multiplies by `PX_TO_PT = 0.75` for the few
  places that need absolute points (font sizes, canvas dimensions).
- `get_box` parses `viewBox` as raw floats — never applies unit conversion
  (viewBox defines a unitless coordinate space, SVG spec §8.1).
- `renderSvg` viewport scale = `canvas_pts / viewBox_user_units`, which
  naturally incorporates ×0.75 for all shape coordinates via the group
  transform.
- SVGs with a `viewBox` but no explicit `width`/`height` now fall back to
  viewBox dimensions for the scale, fixing cropping of such files.
- `DEFAULT_FONT_SIZE` restored to `12` (pt, the CSS default); `em` bases use
  `DEFAULT_FONT_SIZE / PX_TO_PT = 16` user units.
- Regression tests added for bare-number == px consistency at both the
  `convertLength` level and the rendered `fontSize` level.

## ⚠️ Breaking change

Output PDF sizes will differ from 1.x: any SVG whose dimensions are expressed
in user units or `px` will produce a document that is 75% of its previous
linear size (correct physical size per spec).

**Migration** — to restore 1.x dimensions:

```python
drawing = svg2rlg("file.svg")
factor = 4 / 3   # 1 / 0.75
drawing.width  *= factor
drawing.height *= factor
drawing.scale(factor, factor)
```

See `CHANGELOG.rst` for full details.

## Related issues filed

- #448 — `preserveAspectRatio` not implemented (pre-existing, unrelated)
- #449 — SVG 2 viewport units `rem`/`vw`/`vh` not yet supported (future work)