### PR TITLE
Implement preserveAspectRatio for viewBox scaling (issue #448)

### DIFF
--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -1544,6 +1544,42 @@ class SvgRenderer:
             # canvas is in pts; view_box is in user units — scale converts user→pt
             x_scale = (width * PX_TO_PT) / view_box.width if view_box.width else 1
             y_scale = (height * PX_TO_PT) / view_box.height if view_box.height else 1
+
+            # Apply preserveAspectRatio (default: xMidYMid meet)
+            par = (node.getAttribute("preserveAspectRatio") or "xMidYMid meet").strip()
+            par_tokens = par.split()
+            align = par_tokens[0] if par_tokens else "xMidYMid"
+            meet_or_slice = par_tokens[1] if len(par_tokens) > 1 else "meet"
+
+            if align != "none":
+                if meet_or_slice == "slice":
+                    uniform_scale = max(x_scale, y_scale)
+                else:  # meet (default)
+                    uniform_scale = min(x_scale, y_scale)
+
+                # Compute translation to align content within canvas (in pts)
+                width_pt = width * PX_TO_PT
+                height_pt = height * PX_TO_PT
+                scaled_vb_w = view_box.width * uniform_scale
+                scaled_vb_h = view_box.height * uniform_scale
+                # Horizontal alignment
+                if align.startswith("xMin"):
+                    tx = 0
+                elif align.startswith("xMax"):
+                    tx = width_pt - scaled_vb_w
+                else:  # xMid (default)
+                    tx = (width_pt - scaled_vb_w) / 2
+                # Vertical alignment (SVG y increases downward, PDF upward)
+                if "YMin" in align:
+                    ty = height_pt - scaled_vb_h
+                elif "YMax" in align:
+                    ty = 0
+                else:  # YMid (default)
+                    ty = (height_pt - scaled_vb_h) / 2
+                if tx or ty:
+                    group.translate(tx, ty)
+
+                x_scale = y_scale = uniform_scale
             group.scale(x_scale, y_scale * (-1 if outermost else 1))
 
         return group

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1317,6 +1317,75 @@ class TestViewBox:
         )
         assert (drawing.width, drawing.height) == (360.0, 270.0)
 
+    def test_preserve_aspect_ratio_meet_default(self):
+        """Mismatched aspect ratios use uniform (min) scale by default."""
+        drawing = drawing_from_svg(
+            """
+            <?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 width="12cm" height="5.25cm" viewBox="0 0 1200 400">
+                <rect width="100" height="100"/>
+            </svg>
+        """
+        )
+        t = drawing.contents[0].transform
+        x_scale = t[0]
+        y_scale = abs(t[3])
+        assert pytest.approx(x_scale) == y_scale
+
+    def test_preserve_aspect_ratio_none(self):
+        """preserveAspectRatio="none" uses independent x/y scales."""
+        drawing = drawing_from_svg(
+            """
+            <?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 width="12cm" height="5.25cm" viewBox="0 0 1200 400"
+                 preserveAspectRatio="none">
+                <rect width="100" height="100"/>
+            </svg>
+        """
+        )
+        t = drawing.contents[0].transform
+        x_scale = t[0]
+        y_scale = abs(t[3])
+        assert x_scale != pytest.approx(y_scale)
+
+    def test_preserve_aspect_ratio_slice(self):
+        """preserveAspectRatio="xMidYMid slice" uses uniform (max) scale."""
+        drawing = drawing_from_svg(
+            """
+            <?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 width="12cm" height="5.25cm" viewBox="0 0 1200 400"
+                 preserveAspectRatio="xMidYMid slice">
+                <rect width="100" height="100"/>
+            </svg>
+        """
+        )
+        t = drawing.contents[0].transform
+        x_scale = t[0]
+        y_scale = abs(t[3])
+        # slice uses max scale, so the larger scale (y_scale ~0.372) should be used
+        assert pytest.approx(x_scale) == y_scale
+        # The uniform scale should be the larger one (max of the two raw scales, ~0.372)
+        assert x_scale > 0.284
+
+    def test_preserve_aspect_ratio_matched_aspect_ratio(self):
+        """When aspect ratios match exactly, scale is unchanged."""
+        drawing = drawing_from_svg(
+            """
+            <?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 width="1200" height="800" viewBox="-60 -40 120 80">
+                <rect width="10" height="10"/>
+            </svg>
+        """
+        )
+        t = drawing.contents[0].transform
+        x_scale = t[0]
+        y_scale = abs(t[3])
+        assert pytest.approx(x_scale) == y_scale
+
 
 class TestEmbedded:
     def test_svg_in_svg(self):


### PR DESCRIPTION
## Summary

- Implements the `preserveAspectRatio` attribute in `renderSvg`, fixing silent non-uniform distortion when viewBox and canvas aspect ratios differ
- Default behaviour (`xMidYMid meet`) now uses `min(x_scale, y_scale)` and centres content within the canvas
- `slice` mode uses `max(x_scale, y_scale)`
- `none` preserves the previous independent x/y scale behaviour
- Alignment tokens (`xMin`/`xMid`/`xMax`, `YMin`/`YMid`/`YMax`) are honoured via a translate before the scale

## Test plan

- [ ] `TestViewBox::test_preserve_aspect_ratio_meet_default` — mismatched viewBox uses uniform scale
- [ ] `TestViewBox::test_preserve_aspect_ratio_none` — `none` keeps independent scales
- [ ] `TestViewBox::test_preserve_aspect_ratio_slice` — `slice` uses the larger scale
- [ ] `TestViewBox::test_preserve_aspect_ratio_matched_aspect_ratio` — no change when ratios already match
- [ ] All existing tests continue to pass (`75 passed`)

Closes #448