### PR TITLE
Default nested <svg> width/height to parent viewport per SVG1.1 §5.1.2

### DIFF
--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -1496,6 +1496,16 @@ class SvgRenderer:
             width, height = self.shape_converter.convert_length_attrs(
                 node, "width", "height", defaults=(None,) * 2
             )
+            # Per SVG2 §8.2, a nested <svg> with omitted width/height defaults
+            # them to 100% of the parent viewport. Without this fallback, an
+            # inner <svg viewBox="0 0 N N"> with no explicit width/height
+            # renders content at viewBox-unit size instead of filling the
+            # parent slot.
+            if not outermost and _saved_box is not None:
+                if width is None:
+                    width = _saved_box.width
+                if height is None:
+                    height = _saved_box.height
             if height is not None and view_box.height != height:
                 y_scale = height / view_box.height
             if width is not None and view_box.width != width:

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -1496,11 +1496,14 @@ class SvgRenderer:
             width, height = self.shape_converter.convert_length_attrs(
                 node, "width", "height", defaults=(None,) * 2
             )
-            # Per SVG2 §8.2, a nested <svg> with omitted width/height defaults
-            # them to 100% of the parent viewport. Without this fallback, an
-            # inner <svg viewBox="0 0 N N"> with no explicit width/height
-            # renders content at viewBox-unit size instead of filling the
-            # parent slot.
+            # Per SVG 1.1 §5.1.2, a nested <svg> with omitted width/height
+            # defaults them to "100%" of the parent viewport. (SVG 2 §8.2
+            # technically changed this so that omitting either resolves to 0
+            # and disables rendering, but no browser implements that and most
+            # real-world SVGs still rely on the 1.1 behavior.) Without this
+            # fallback, an inner <svg viewBox="0 0 N N"> with no explicit
+            # width/height renders content at viewBox-unit size instead of
+            # filling the parent slot.
             if not outermost and _saved_box is not None:
                 if width is None:
                     width = _saved_box.width

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1342,6 +1342,28 @@ class TestEmbedded:
         inner_rect = drawing.contents[0].contents[1].contents[0]
         assert inner_rect.width == 15
 
+    def test_nested_svg_without_width_height(self):
+        """A nested <svg viewBox="..."> with omitted width/height should
+        default to 100% of the parent viewport (SVG2 §8.2). Without the
+        fallback, the viewBox-to-viewport scaling was skipped and inner
+        content rendered at viewBox-unit size instead of filling the slot."""
+        drawing = drawing_from_svg(
+            """
+            <?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
+                 width="200" height="200">
+              <svg viewBox="0 0 50 50">
+                <rect x="0" y="0" width="50" height="50"/>
+              </svg>
+            </svg>
+        """
+        )
+        nested_group = drawing.contents[0].contents[0]
+        transform = nested_group.getProperties()["transform"]
+        # Parent viewport is 200x200, nested viewBox is 50x50 → scale 4x
+        assert transform[0] == 4
+        assert transform[3] == 4
+
     def test_png_in_svg_file_like(self):
         drawing = drawing_from_svg(
             """

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1344,9 +1344,10 @@ class TestEmbedded:
 
     def test_nested_svg_without_width_height(self):
         """A nested <svg viewBox="..."> with omitted width/height should
-        default to 100% of the parent viewport (SVG2 §8.2). Without the
-        fallback, the viewBox-to-viewport scaling was skipped and inner
-        content rendered at viewBox-unit size instead of filling the slot."""
+        default to 100% of the parent viewport (SVG 1.1 §5.1.2). Without
+        the fallback, the viewBox-to-viewport scaling was skipped and
+        inner content rendered at viewBox-unit size instead of filling
+        the slot."""
         drawing = drawing_from_svg(
             """
             <?xml version="1.0"?>
@@ -1359,10 +1360,12 @@ class TestEmbedded:
         """
         )
         nested_group = drawing.contents[0].contents[0]
-        transform = nested_group.getProperties()["transform"]
-        # Parent viewport is 200x200, nested viewBox is 50x50 → scale 4x
-        assert transform[0] == 4
-        assert transform[3] == 4
+        xmin, ymin, xmax, ymax = nested_group.getBounds()
+        # Parent viewport is 200x200, inner viewBox is 50x50, so the rect
+        # should be rendered at the full 200x200 — not 50x50, which is what
+        # happens without the fallback.
+        assert xmax - xmin == 200
+        assert ymax - ymin == 200
 
     def test_png_in_svg_file_like(self):
         drawing = drawing_from_svg(


### PR DESCRIPTION
## Problem

When a nested `<svg>` element has a `viewBox` but omits `width` / `height`,
`renderSvg` leaves both at `None` and skips the viewBox-to-viewport scaling
entirely. Inner content then renders at viewBox-unit size instead of filling
the parent slot.

Per [SVG 1.1 §5.1.2](https://www.w3.org/TR/SVG11/struct.html#SVGElementWidthAttribute),
those attributes default to `100%` of the parent viewport, so the scaling
*should* be applied — the parent's viewport size mapped onto the nested
viewBox.

(SVG 2 actually changed this rule so that omitting either resolves to 0
and disables rendering, but no browser implements that and most real-world
SVGs follow SVG 1.1. svglib isn't trying to support SVG 2 yet, so the SVG 1.1
behavior is what matches user expectation.)


### Real-world impact

This is what made me hit it: the [`chqr`](https://pypi.org/project/chqr/)
package (Swiss QR-bills) embeds the QR code as a nested
`<svg viewBox="0 0 N N">` with no `width` / `height`. With the current code,
the QR comes out at ~25 % of its intended 46 mm size, regardless of any
outer scaling.

## Fix

In the `elif view_box:` branch of `renderSvg`, fall back to `_saved_box`
(the parent viewport, already captured at the top of the method) when
`width` or `height` is `None` and we're not at the outermost svg.

```python
if not outermost and _saved_box is not None:
    if width is None:
        width = _saved_box.width
    if height is None:
        height = _saved_box.height
```

This is safe by construction:

Outermost svg — branch is skipped, behavior unchanged.
Nested svg with explicit width / height — fallback is skipped, behavior unchanged.
Nested svg with viewBox but no width / height (the broken case) — now scales to fill the parent viewport.
The existing TestEmbedded::test_svg_in_svg and test_embedded_svg_with_percentages continue to pass.

## Test
Added TestEmbedded::test_nested_svg_without_width_height asserting
scale = 4 for a 50×50 viewBox inside a 200×200 parent.

Full unit-test suite (tests/test_basic.py + tests/test_fonts.py):
112 passed, no regressions.