### PR TITLE
Warn when loading SVGs from Inkscape <0.92 (90 dpi)

### DIFF
--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -161,6 +161,7 @@ def find_font(
 
 
 XML_NS = "http://www.w3.org/XML/1998/namespace"
+INKSCAPE_NS = "http://www.inkscape.org/namespaces/inkscape"
 
 # A sentinel to identify a situation where a node reference a fragment not yet defined.
 DELAYED = object()
@@ -964,6 +965,24 @@ class SvgRenderer:
         self._external_svgs: Dict[str, ExternalSVG] = {}
         self.attrConverter.css_rules = CSSMatcher()
 
+    def _warn_old_inkscape(self, svg_node: Any) -> None:
+        inkscape_version = svg_node.get(f"{{{INKSCAPE_NS}}}version", "")
+        if not inkscape_version:
+            return
+        version_str = inkscape_version.split()[0]
+        try:
+            parts = tuple(int(x) for x in version_str.split(".")[:2])
+        except ValueError:
+            return
+        if parts < (0, 92):
+            logger.warning(
+                "This SVG was created with Inkscape %s (pre-0.92, 90 dpi). "
+                "Coordinates assume 90 dpi instead of the standard 96 dpi, "
+                "so the output may be ~6.7%% too large. "
+                "Re-save with Inkscape ≥0.92 to fix.",
+                version_str,
+            )
+
     def render(self, svg_node: Any) -> Drawing:
         """Render an SVG node into a ReportLab Drawing.
 
@@ -974,6 +993,7 @@ class SvgRenderer:
             A ReportLab Drawing object representing the SVG.
         """
         node = NodeTracker.from_xml_root(svg_node)
+        self._warn_old_inkscape(svg_node)
         view_box = self.get_box(node, default_box=True)
         # Knowing the main box is useful for percentage units
         self.attrConverter.set_box(view_box)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1471,6 +1471,41 @@ class TestEmbedded:
         assert xmax - xmin == pytest.approx(150)
         assert ymax - ymin == pytest.approx(150)
 
+    def test_old_inkscape_warning(self, caplog):
+        """SVGs from Inkscape <0.92 (90 dpi) should log a warning; newer should not."""
+        old_svg = """<?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+                 inkscape:version="0.91 r13725"
+                 width="100" height="100">
+              <rect width="100" height="100"/>
+            </svg>"""
+        new_svg = """<?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+                 inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+                 width="100" height="100">
+              <rect width="100" height="100"/>
+            </svg>"""
+        plain_svg = """<?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+              <rect width="100" height="100"/>
+            </svg>"""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="svglib.svglib"):
+            drawing_from_svg(old_svg)
+        assert any("pre-0.92" in r.message for r in caplog.records)
+
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="svglib.svglib"):
+            drawing_from_svg(new_svg)
+        assert not caplog.records
+
+        with caplog.at_level(logging.WARNING, logger="svglib.svglib"):
+            drawing_from_svg(plain_svg)
+        assert not caplog.records
+
     def test_png_in_svg_file_like(self):
         drawing = drawing_from_svg(
             """


### PR DESCRIPTION
## Summary

Inkscape before 0.92 used 90 dpi as its reference resolution rather than the CSS/SVG standard 96 dpi. Files produced by these old versions embed coordinates scaled for 90 dpi, causing svglib to render them ~6.7% too large (96/90 ≈ 1.067).

- Add `INKSCAPE_NS` constant for the Inkscape XML namespace
- Add `SvgRenderer._warn_old_inkscape()` which reads `inkscape:version` from the root `<svg>` element; if the parsed major.minor version is below 0.92, emit a `logger.warning` directing the user to re-save with a modern Inkscape
- Called once at the start of `SvgRenderer.render()`
- No change to rendering behaviour — warning only

## Test plan

- [x] `TestEmbedded::test_old_inkscape_warning` — old version triggers warning, 0.92+ and plain SVGs do not

Closes #452