### PR TITLE
Add SVG 2 length units: rem, vw, vh, vmin, vmax, q

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,10 @@ returned ``Drawing`` object before use::
     drawing.height *= factor
     drawing.scale(factor, factor)
 
+- Add support for SVG 2 length units: ``rem``, ``vw``, ``vh``, ``vmin``,
+  ``vmax``, and ``q`` (quarter-millimetre) in ``convertLength`` (#449).
+- Warn when loading SVGs created with Inkscape < 0.92, which used a
+  non-standard 90 dpi reference resolution (#452).
 - Move ``rlpycairo`` to the ``bitmaps`` extra, so Cairo is no longer part of
   the default installation path.
 - Fix inconsistent unit handling: bare numbers and ``px`` units now produce

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -545,8 +545,38 @@ class Svg2RlgAttributeConverter(AttributeConverter):
         elif text.endswith("pt"):
             # 1 pt = 1/72 in = 96/72 px user units
             return float(text[:-2]) * (96 / 72)
+        elif text.endswith("rem"):
+            # root em — always the CSS default 16 px (= DEFAULT_FONT_SIZE / PX_TO_PT)
+            return float(text[:-3]) * (DEFAULT_FONT_SIZE / PX_TO_PT)
         elif text.endswith("em"):
             return float(text[:-2]) * em_base
+        elif text.endswith("vmin"):
+            if self.main_box is None:
+                logger.error("Unable to resolve vmin unit without a main box")
+                return default
+            return (
+                float(text[:-4]) / 100 * min(self.main_box.width, self.main_box.height)
+            )
+        elif text.endswith("vmax"):
+            if self.main_box is None:
+                logger.error("Unable to resolve vmax unit without a main box")
+                return default
+            return (
+                float(text[:-4]) / 100 * max(self.main_box.width, self.main_box.height)
+            )
+        elif text.endswith("vw"):
+            if self.main_box is None:
+                logger.error("Unable to resolve vw unit without a main box")
+                return default
+            return float(text[:-2]) / 100 * self.main_box.width
+        elif text.endswith("vh"):
+            if self.main_box is None:
+                logger.error("Unable to resolve vh unit without a main box")
+                return default
+            return float(text[:-2]) / 100 * self.main_box.height
+        elif text.endswith("q"):
+            # 1q = 0.25 mm
+            return float(text[:-1]) * toLength("1mm") / (4 * PX_TO_PT)
         elif text.endswith("px"):
             # px are user units (1:1)
             return float(text[:-2])

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -237,3 +237,87 @@ class TestFontSizeUnits:
             _font_size_pt("72pt"),
             rel_tol=1e-4,
         )
+
+
+# ---------------------------------------------------------------------------
+# SVG 2 viewport and root-relative units (issue #449)
+# ---------------------------------------------------------------------------
+
+
+def _converter_with_box(width: float, height: float):
+    """Return an Svg2RlgAttributeConverter with main_box set to the given size."""
+    from svglib.svglib import Box, Svg2RlgAttributeConverter
+
+    conv = Svg2RlgAttributeConverter()
+    conv.set_box(Box(0, 0, width, height))
+    return conv
+
+
+class TestSVG2ViewportUnits:
+    """rem, vw, vh, vmin, vmax, q — SVG 2 / CSS length units."""
+
+    def test_rem_equals_16px(self):
+        """1rem == 16 user units (CSS default root font-size)."""
+        conv = _converter_with_box(400, 300)
+        assert math.isclose(conv.convertLength("1rem"), 16.0)
+        assert math.isclose(conv.convertLength("2rem"), 32.0)
+
+    def test_rem_matches_16px_literal(self):
+        """1rem and 16px must produce identical lengths."""
+        conv = _converter_with_box(400, 300)
+        assert math.isclose(conv.convertLength("1rem"), conv.convertLength("16px"))
+
+    def test_vw_fraction_of_viewport_width(self):
+        """50vw == 50% of viewport width (200 user units for a 400-wide box)."""
+        conv = _converter_with_box(400, 300)
+        assert math.isclose(conv.convertLength("50vw"), 200.0)
+        assert math.isclose(conv.convertLength("100vw"), 400.0)
+
+    def test_vh_fraction_of_viewport_height(self):
+        """50vh == 50% of viewport height (150 user units for a 300-tall box)."""
+        conv = _converter_with_box(400, 300)
+        assert math.isclose(conv.convertLength("50vh"), 150.0)
+        assert math.isclose(conv.convertLength("100vh"), 300.0)
+
+    def test_vmin_uses_smaller_dimension(self):
+        """100vmin == the smaller of viewport width and height."""
+        conv = _converter_with_box(400, 300)
+        assert math.isclose(conv.convertLength("100vmin"), 300.0)
+
+    def test_vmax_uses_larger_dimension(self):
+        """100vmax == the larger of viewport width and height."""
+        conv = _converter_with_box(400, 300)
+        assert math.isclose(conv.convertLength("100vmax"), 400.0)
+
+    def test_vmin_vmax_square_viewport_equal(self):
+        """For a square viewport, vmin == vmax."""
+        conv = _converter_with_box(200, 200)
+        assert math.isclose(conv.convertLength("50vmin"), conv.convertLength("50vmax"))
+
+    def test_q_quarter_millimetre(self):
+        """4q == 1mm (q is a quarter-millimetre)."""
+        conv = _converter_with_box(400, 300)
+        assert math.isclose(
+            conv.convertLength("4q"), conv.convertLength("1mm"), rel_tol=1e-4
+        )
+
+    def test_q_100_equals_25mm(self):
+        """100q == 25mm."""
+        conv = _converter_with_box(400, 300)
+        assert math.isclose(
+            conv.convertLength("100q"), conv.convertLength("25mm"), rel_tol=1e-4
+        )
+
+    def test_vw_used_in_svg_rect(self):
+        """A rect with width="50vw" in a 400-unit viewport is 200 user units wide."""
+        drawing = drawing_from_svg(
+            """<?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 width="400" height="300" viewBox="0 0 400 300">
+              <rect id="r" x="0" y="0" width="50vw" height="50vh"/>
+            </svg>"""
+        )
+        rect = drawing.contents[0].contents[0]
+        # rect stores dimensions in user units; the group transform converts to pts
+        assert math.isclose(rect.width, 200.0, rel_tol=1e-4)
+        assert math.isclose(rect.height, 150.0, rel_tol=1e-4)


### PR DESCRIPTION
## Summary

Implements the six SVG 2 / CSS length units that were missing from `convertLength` (issue #449):

| Unit | Meaning | Resolution |
|------|---------|------------|
| `rem` | Root element font-size | CSS default 16 px (`DEFAULT_FONT_SIZE / PX_TO_PT`) |
| `vw` | 1% of viewport width | `main_box.width / 100` |
| `vh` | 1% of viewport height | `main_box.height / 100` |
| `vmin` | 1% of the smaller viewport dimension | `min(w, h) / 100` |
| `vmax` | 1% of the larger viewport dimension | `max(w, h) / 100` |
| `q` | Quarter-millimetre (0.25 mm) | `toLength("1mm") / (4 × PX_TO_PT)` |

`rem` is checked before `em` to prevent `"5rem"` from matching the `em` branch. `vw`/`vh`/`vmin`/`vmax` log an error and return the default when `main_box` is `None`.

## Test plan

- [x] `TestSVG2ViewportUnits::test_rem_equals_16px`
- [x] `TestSVG2ViewportUnits::test_rem_matches_16px_literal`
- [x] `TestSVG2ViewportUnits::test_vw_fraction_of_viewport_width`
- [x] `TestSVG2ViewportUnits::test_vh_fraction_of_viewport_height`
- [x] `TestSVG2ViewportUnits::test_vmin_uses_smaller_dimension`
- [x] `TestSVG2ViewportUnits::test_vmax_uses_larger_dimension`
- [x] `TestSVG2ViewportUnits::test_vmin_vmax_square_viewport_equal`
- [x] `TestSVG2ViewportUnits::test_q_quarter_millimetre`
- [x] `TestSVG2ViewportUnits::test_q_100_equals_25mm`
- [x] `TestSVG2ViewportUnits::test_vw_used_in_svg_rect`

Closes #449