### PR TITLE
Resolve rem against root <svg> font-size

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,8 @@ returned ``Drawing`` object before use::
 
 - Add support for SVG 2 length units: ``rem``, ``vw``, ``vh``, ``vmin``,
   ``vmax``, and ``q`` (quarter-millimetre) in ``convertLength`` (#449).
+- ``rem`` now resolves against the root ``<svg>`` element's ``font-size``
+  (falling back to the CSS default of 16 px when not set).
 - Warn when loading SVGs created with Inkscape < 0.92, which used a
   non-standard 90 dpi reference resolution (#452).
 - Move ``rlpycairo`` to the ``bitmaps`` extra, so Cairo is no longer part of

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -312,6 +312,8 @@ class AttributeConverter:
     def __init__(self) -> None:
         self.css_rules: Optional[CSSMatcher] = None
         self.main_box: Optional[Box] = None
+        # Resolved once at render time from the root <svg> font-size; used by rem.
+        self.root_font_size: float = DEFAULT_FONT_SIZE / PX_TO_PT  # 16 px default
 
     def set_box(self, main_box: Optional[Box]) -> None:
         """Set the main viewbox for resolving percentage-based units.
@@ -546,8 +548,7 @@ class Svg2RlgAttributeConverter(AttributeConverter):
             # 1 pt = 1/72 in = 96/72 px user units
             return float(text[:-2]) * (96 / 72)
         elif text.endswith("rem"):
-            # root em — always the CSS default 16 px (= DEFAULT_FONT_SIZE / PX_TO_PT)
-            return float(text[:-3]) * (DEFAULT_FONT_SIZE / PX_TO_PT)
+            return float(text[:-3]) * self.root_font_size
         elif text.endswith("em"):
             return float(text[:-2]) * em_base
         elif text.endswith("vmin"):
@@ -995,6 +996,13 @@ class SvgRenderer:
         self._external_svgs: Dict[str, ExternalSVG] = {}
         self.attrConverter.css_rules = CSSMatcher()
 
+    def _set_root_font_size(self, root_node: Any) -> None:
+        fs_str = self.attrConverter.findAttr(root_node, "font-size")
+        if fs_str:
+            fs_px = self.attrConverter.convertLength(fs_str)
+            if fs_px:
+                self.attrConverter.root_font_size = float(fs_px)  # type: ignore[arg-type]
+
     def _warn_old_inkscape(self, svg_node: Any) -> None:
         inkscape_version = svg_node.get(f"{{{INKSCAPE_NS}}}version", "")
         if not inkscape_version:
@@ -1024,6 +1032,7 @@ class SvgRenderer:
         """
         node = NodeTracker.from_xml_root(svg_node)
         self._warn_old_inkscape(svg_node)
+        self._set_root_font_size(node)
         view_box = self.get_box(node, default_box=True)
         # Knowing the main box is useful for percentage units
         self.attrConverter.set_box(view_box)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -256,16 +256,44 @@ def _converter_with_box(width: float, height: float):
 class TestSVG2ViewportUnits:
     """rem, vw, vh, vmin, vmax, q — SVG 2 / CSS length units."""
 
-    def test_rem_equals_16px(self):
-        """1rem == 16 user units (CSS default root font-size)."""
+    def test_rem_equals_16px_default(self):
+        """1rem == 16 user units when root has no explicit font-size (CSS default)."""
         conv = _converter_with_box(400, 300)
         assert math.isclose(conv.convertLength("1rem"), 16.0)
         assert math.isclose(conv.convertLength("2rem"), 32.0)
 
     def test_rem_matches_16px_literal(self):
-        """1rem and 16px must produce identical lengths."""
+        """1rem and 16px must produce identical lengths when using the default."""
         conv = _converter_with_box(400, 300)
         assert math.isclose(conv.convertLength("1rem"), conv.convertLength("16px"))
+
+    def test_rem_uses_root_font_size_from_svg(self):
+        """rem resolves against the root <svg> font-size, not always 16px."""
+        drawing = drawing_from_svg(
+            """<?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 width="400" height="300" viewBox="0 0 400 300"
+                 font-size="20px">
+              <rect x="0" y="0" width="2rem" height="1rem"/>
+            </svg>"""
+        )
+        rect = drawing.contents[0].contents[0]
+        # 2rem = 2 * 20px = 40 user units; 1rem = 20 user units
+        assert math.isclose(rect.width, 40.0, rel_tol=1e-4)
+        assert math.isclose(rect.height, 20.0, rel_tol=1e-4)
+
+    def test_rem_default_when_no_root_font_size(self):
+        """rem defaults to 16px when root <svg> has no explicit font-size."""
+        drawing = drawing_from_svg(
+            """<?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 width="400" height="300" viewBox="0 0 400 300">
+              <rect x="0" y="0" width="1rem" height="1rem"/>
+            </svg>"""
+        )
+        rect = drawing.contents[0].contents[0]
+        assert math.isclose(rect.width, 16.0, rel_tol=1e-4)
+        assert math.isclose(rect.height, 16.0, rel_tol=1e-4)
 
     def test_vw_fraction_of_viewport_width(self):
         """50vw == 50% of viewport width (200 user units for a 400-wide box)."""


### PR DESCRIPTION
## Summary

Follow-up to #458 (SVG 2 units). The initial `rem` implementation always resolved to the CSS default of 16 px. This PR makes it spec-correct by reading the actual root `<svg>` element's `font-size` at the start of rendering.

**Changes:**
- `AttributeConverter.__init__` gains `root_font_size: float` (default `DEFAULT_FONT_SIZE / PX_TO_PT` = 16 px)
- New `SvgRenderer._set_root_font_size(root_node)` reads `font-size` from the root `<svg>` via `findAttr`, converts it to user units, and stores it on `attrConverter.root_font_size`
- Called once at the top of `SvgRenderer.render()`, before the tree walk
- `convertLength`'s `rem` branch now uses `self.root_font_size` instead of the hardcoded constant

The fallback to 16 px is preserved when the root `<svg>` has no explicit `font-size`.

## Test plan

- [x] `test_rem_equals_16px_default` — no root font-size → 1rem == 16px
- [x] `test_rem_matches_16px_literal` — 1rem == 16px literal (default case)
- [x] `test_rem_uses_root_font_size_from_svg` — `font-size="20px"` on root → 1rem == 20px
- [x] `test_rem_default_when_no_root_font_size` — rect using `1rem` in a plain SVG → 16px