### PR TITLE
Supply chain hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.0.1 (2026-06-17)
+
+Supply-chain hygiene release — no code changes.
+
+This release replaces 2.0.0, which was published directly with `uv publish`
+and therefore lacked the PEP 740 provenance attestation that was present in
+1.6.0. Releases must be triggered via the GitHub Actions release workflow
+(`publish-to-pypi.yml`), which uses PyPI Trusted Publishing (OIDC) to produce
+a SLSA Level 3 attestation. Publishing locally — even with
+`uv publish --trusted-publishing` — relies on a local OAuth identity and does
+not meet that bar.
+
+- Declare `pillow>=9.0.0` as a direct dependency; it was previously an
+  undeclared transitive dependency pulled in by reportlab (#463).
+
 ## 2.0.0 (2026-06-16)
 
 Identical to 2.0b1 in terms of code; this release promotes the beta to a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ requires-python = ">=3.9"
 dependencies = [
     "cssselect2>=0.2.0",
     "lxml>=6.0.0",
+    "pillow>=9.0.0",
     "reportlab>=4.4.3",
     "tinycss2>=0.6.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svglib"
-version = "2.0.0"
+version = "2.0.1"
 description = "A pure-Python library for reading and converting SVG"
 readme = "README.md"
 authors = [{ name = "Dinu Gherman" }]

--- a/uv.lock
+++ b/uv.lock
@@ -824,11 +824,12 @@ wheels = [
 
 [[package]]
 name = "svglib"
-version = "2.0b1"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "cssselect2" },
     { name = "lxml" },
+    { name = "pillow" },
     { name = "reportlab" },
     { name = "tinycss2" },
 ]
@@ -863,6 +864,7 @@ test = [
 requires-dist = [
     { name = "cssselect2", specifier = ">=0.2.0" },
     { name = "lxml", specifier = ">=6.0.0" },
+    { name = "pillow", specifier = ">=9.0.0" },
     { name = "reportlab", specifier = ">=4.4.3" },
     { name = "rlpycairo", marker = "extra == 'bitmaps'", specifier = ">=0.4.0" },
     { name = "tinycss2", specifier = ">=0.6.0" },


### PR DESCRIPTION
No make publish target was added because using `uv publish` would use a local OAuth identity resulting in an invalid SLSA Level 3 attestation. The GitHub workflow should be used as it produces a valid SLSA Level 3 attestation.