### PR TITLE
Implement getBounds() on gradient shapes (fixes #466)

### DIFF
--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -998,6 +998,10 @@ class LinearGradientShape(DirectDraw):
         )
         canvas.restoreState()
 
+    def getBounds(self):
+        """Return the bounds of the clipped region this gradient fills."""
+        return self._clip_shape.getBounds()
+
 
 class RadialGradientShape(DirectDraw):
     """Fills a clipped region with a radial gradient via PDF shading."""
@@ -1032,6 +1036,10 @@ class RadialGradientShape(DirectDraw):
             self._extend,
         )
         canvas.restoreState()
+
+    def getBounds(self):
+        """Return the bounds of the clipped region this gradient fills."""
+        return self._clip_shape.getBounds()
 
 
 # Deprecated aliases for the underscore-prefixed names these classes had before

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -998,9 +998,9 @@ class LinearGradientShape(DirectDraw):
         )
         canvas.restoreState()
 
-    def getBounds(self):
+    def getBounds(self) -> Tuple[float, float, float, float]:
         """Return the bounds of the clipped region this gradient fills."""
-        return self._clip_shape.getBounds()
+        return cast(Tuple[float, float, float, float], self._clip_shape.getBounds())
 
 
 class RadialGradientShape(DirectDraw):
@@ -1037,9 +1037,9 @@ class RadialGradientShape(DirectDraw):
         )
         canvas.restoreState()
 
-    def getBounds(self):
+    def getBounds(self) -> Tuple[float, float, float, float]:
         """Return the bounds of the clipped region this gradient fills."""
-        return self._clip_shape.getBounds()
+        return cast(Tuple[float, float, float, float], self._clip_shape.getBounds())
 
 
 # Deprecated aliases for the underscore-prefixed names these classes had before

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1675,6 +1675,10 @@ class TestGradients:
         groups = self._find_groups(drawing)
         # The rect's fill must have been replaced by a gradient group
         assert len(groups) > 1
+        # The gradient shape must implement getBounds() so the drawing can be
+        # measured (e.g. when used as a flowable by rst2pdf); see issue #466.
+        x0, y0, x1, y1 = drawing.getBounds()
+        assert x1 > x0 and y1 > y0
 
     def test_radial_gradient_circle(self):
         """A circle with a radialGradient fill must produce a Group."""
@@ -1695,6 +1699,9 @@ class TestGradients:
         )
         groups = self._find_groups(drawing)
         assert len(groups) > 1
+        # See issue #466: the gradient shape must implement getBounds().
+        x0, y0, x1, y1 = drawing.getBounds()
+        assert x1 > x0 and y1 > y0
 
     def test_gradient_stops_parsed(self):
         """Stop colors and offsets must be correctly stored in gradient_defs."""


### PR DESCRIPTION
Fixes #466.

## Problem

`_LinearGradientShape` and `_RadialGradientShape` subclass reportlab's `DirectDraw` → `Shape`, whose inherited `getBounds()` raises `NotImplementedError`. Any consumer that measures a drawing's bounds crashes on a gradient-filled SVG:

```
NotImplementedError: Shapes and widgets must implement getBounds
```

This bites rst2pdf (which lays a `Drawing` out as a flowable and computes its bounds to scale/fit it) and `Drawing.getBounds()`, which recurses into every child shape.

## Why existing tests missed it

Plain `renderPDF.drawToFile(...)` sizes the page from `drawing.width`/`drawing.height` and never calls `getBounds()`, so rendering a gradient SVG to PDF (including the `gradient_showcase.svg` sample) always worked. No test ever *measured* a gradient drawing.

## Fix

Delegate `getBounds()` to the gradient's clip shape — that shape *is* the region the gradient fills, so its bounds are the gradient's bounds.

The existing linear/radial gradient tests now also assert `drawing.getBounds()` returns a sane non-empty box. Reverting the source change makes both tests fail with the original `NotImplementedError`, confirming they guard the regression.