### PR TITLE
Make gradient shape classes public (drop leading underscore)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Type-safety and tooling improvements — no runtime behavior changes.
 - Tightened internal gradient handling types: parsed gradient definitions now
   use a `TypedDict` instead of an opaque `Dict[str, Any]`, and the internal
   group/parent parameters are typed as `Optional[Group]`.
+- Renamed the gradient shape classes `_LinearGradientShape` and
+  `_RadialGradientShape` to `LinearGradientShape` and `RadialGradientShape`.
+  They appear in the rendered `Drawing` tree and were never meant to be
+  private, so the leading underscore was misleading. The old underscore-
+  prefixed names remain as deprecated aliases and will be **removed in 2.1.0**.
 
 ## 2.0.2 (2026-06-18)
 

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -59,6 +59,7 @@ from reportlab.graphics.shapes import (
     Polygon,
     PolyLine,
     Rect,
+    Shape,
     SolidShape,
     String,
     _renderPath,
@@ -960,17 +961,17 @@ def _find_clip_shape(item: Any) -> Optional[Any]:
     return None
 
 
-class _LinearGradientShape(DirectDraw):
+class LinearGradientShape(DirectDraw):
     """Fills a clipped region with a linear gradient via PDF shading."""
 
     def __init__(
         self,
-        clip_shape: Any,
+        clip_shape: Shape,
         x0: float,
         y0: float,
         x1: float,
         y1: float,
-        rl_colors: List[Any],
+        rl_colors: List[colors.Color],
         positions: List[float],
         extend: bool = True,
     ) -> None:
@@ -998,16 +999,16 @@ class _LinearGradientShape(DirectDraw):
         canvas.restoreState()
 
 
-class _RadialGradientShape(DirectDraw):
+class RadialGradientShape(DirectDraw):
     """Fills a clipped region with a radial gradient via PDF shading."""
 
     def __init__(
         self,
-        clip_shape: Any,
+        clip_shape: Shape,
         cx: float,
         cy: float,
         r: float,
-        rl_colors: List[Any],
+        rl_colors: List[colors.Color],
         positions: List[float],
         extend: bool = True,
     ) -> None:
@@ -1031,6 +1032,13 @@ class _RadialGradientShape(DirectDraw):
             self._extend,
         )
         canvas.restoreState()
+
+
+# Deprecated aliases for the underscore-prefixed names these classes had before
+# they were made public. They were never meant to be private, but the leading
+# underscore wrongly signalled so. Scheduled for removal in 2.1.0.
+_LinearGradientShape = LinearGradientShape
+_RadialGradientShape = RadialGradientShape
 
 
 # ## the main meat ###
@@ -1369,7 +1377,7 @@ class SvgRenderer:
                 y1 = by0 + y1 * bbox_h
                 x2 = bx0 + x2 * bbox_w
                 y2 = by0 + y2 * bbox_h
-            grad_shape: DirectDraw = _LinearGradientShape(
+            grad_shape: DirectDraw = LinearGradientShape(
                 clip_shape, x1, y1, x2, y2, rl_colors, positions, extend
             )
         else:
@@ -1380,7 +1388,7 @@ class SvgRenderer:
                 cx = bx0 + cx * bbox_w
                 cy = by0 + cy * bbox_h
                 r = r * (bbox_w + bbox_h) / 2.0
-            grad_shape = _RadialGradientShape(
+            grad_shape = RadialGradientShape(
                 clip_shape, cx, cy, r, rl_colors, positions, extend
             )
 


### PR DESCRIPTION
Follow-up to #467 (discussion about the gradient shape naming).

## Why

`_LinearGradientShape` and `_RadialGradientShape` are instantiated by the renderer and placed into the `Drawing` object tree that `svg2rlg()` returns. They are peers of the **public** `NoStrokePath` and `ClippingPath` shapes, which carry no leading underscore. The `_` wrongly signalled "private, may disappear" for objects that every downstream consumer walking the tree encounters (e.g. rst2pdf in #466).

## What

- Rename `_LinearGradientShape` → `LinearGradientShape` and `_RadialGradientShape` → `RadialGradientShape`, and update internal references.
- Keep the old underscore-prefixed names as **deprecated aliases** (`_LinearGradientShape = LinearGradientShape`, etc.) for backward compatibility.
- The aliases are scheduled for removal in **2.1.0**, noted in `CHANGELOG.md` under an **Unreleased** section.

## Notes

- No behaviour change; purely a naming/compatibility change.
- Branched off `main` and touches only the class-definition / instantiation lines, so it does not conflict with the `getBounds()` fix in #467 regardless of merge order.
- Full `test_basic.py` suite passes (79); aliases verified to resolve to the renamed classes.