### PR TITLE
Remove defunct uniconv sample tests

### DIFF
--- a/tests/README.rst
+++ b/tests/README.rst
@@ -103,12 +103,6 @@ more code being executed and a higher test coverage)::
 
     =============== 32 passed, 4 skipped in 637.65 seconds ===============
 
-As an experimental feature some of the tests try using a vector
-conversion tool named `UniConvertor
-<http://sourceforge.net/projects/uniconvertor>`_
-(if installed) for producing PDFs for comparison with `svglib`.
-(This was not used for years, though, during development/testing.)
-
 Calling ``renderPM.drawToFile()`` in ``TestW3CSVG.test_convert_pdf_png()``
 is known to raise a ``TypeError`` sometimes in reportlab which was
 fixed in ``reportlab`` 3.3.26. See

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -1,8 +1,6 @@
 """Testsuite for svglib.
 
 This module tests conversion of sample SVG files into PDF files.
-Some tests try using a tool called uniconv (if installed)
-to convert SVG files into PDF for comparision with svglib.
 
 Run with one of these lines from inside the test directory:
 
@@ -20,7 +18,7 @@ import tarfile
 import textwrap
 import time
 from http.client import HTTPSConnection
-from os.path import basename, dirname, exists, getsize, join, splitext
+from os.path import basename, dirname, exists, join, splitext
 from typing import Any
 from urllib.parse import quote, unquote, urlparse
 
@@ -41,13 +39,6 @@ def has_renderpm_backend() -> bool:
     except renderPM.RenderPMError:
         return False
     return True
-
-
-def found_uniconv() -> bool:
-    "Do we have uniconv installed?"
-
-    res = os.popen("which uniconv").read().strip()
-    return len(res) > 0
 
 
 def fetch_file(
@@ -142,18 +133,6 @@ class TestSVGSamples:
             base = splitext(path)[0] + "-svglib.pdf"
             renderPDF.drawToFile(drawing, base, showBoundary=0)
 
-    @pytest.mark.skipif(not found_uniconv(), reason="needs uniconv")
-    def test_create_pdf_uniconv(self):
-        "Test converting sample SVG files to PDF using uniconverter."
-
-        paths = glob.glob(f"{TEST_ROOT}/samples/misc/*.svg")
-        for path in paths:
-            out = splitext(path)[0] + "-uniconv.pdf"
-            cmd = f"uniconv '{path}' '{out}'"
-            os.popen(cmd).read()
-            if exists(out) and getsize(out) == 0:
-                os.remove(out)
-
 
 class TestWikipediaSymbols:
     "Tests on sample symbol SVG files from wikipedia.org."
@@ -227,19 +206,6 @@ class TestWikipediaSymbols:
             # save as PDF
             base = splitext(path)[0] + "-svglib.pdf"
             renderPDF.drawToFile(drawing, base, showBoundary=0)
-
-    @pytest.mark.skipif(not found_uniconv(), reason="needs uniconv")
-    def test_convert_pdf_uniconv(self):
-        "Test converting symbol SVG files to PDF using uniconverter."
-
-        paths = glob.glob(f"{self.folder_path}/*")
-        paths = [p for p in paths if splitext(p.lower())[1] in [".svg", ".svgz"]]
-        for path in paths:
-            out = splitext(path)[0] + "-uniconv.pdf"
-            cmd = f"uniconv '{path}' '{out}'"
-            os.popen(cmd).read()
-            if exists(out) and getsize(out) == 0:
-                os.remove(out)
 
 
 class TestWikipediaFlags:
@@ -362,19 +328,6 @@ class TestWikipediaFlags:
             base = splitext(path)[0] + "-svglib.pdf"
             renderPDF.drawToFile(drawing, base, showBoundary=0)
 
-    @pytest.mark.skipif(not found_uniconv(), reason="needs uniconv")
-    def test_convert_pdf_uniconv(self):
-        "Test converting flag SVG files to PDF using uniconverer."
-
-        paths = glob.glob(f"{self.folder_path}/*")
-        paths = [p for p in paths if splitext(p.lower())[1] in [".svg", ".svgz"]]
-        for path in paths:
-            out = splitext(path)[0] + "-uniconv.pdf"
-            cmd = f"uniconv '{path}' '{out}'"
-            os.popen(cmd).read()
-            if exists(out) and getsize(out) == 0:
-                os.remove(out)
-
 
 class TestW3CSVG:
     "Tests using the official W3C SVG testsuite."
@@ -411,7 +364,6 @@ class TestW3CSVG:
         "Remove generated files when running this test class."
 
         paths = glob.glob(join(self.folder_path, "svg/*-svglib.pdf"))
-        paths += glob.glob(join(self.folder_path, "svg/*-uniconv.pdf"))
         paths += glob.glob(join(self.folder_path, "svg/*-svglib.png"))
         for i, path in enumerate(paths):
             print(f"deleting [{i}] {path}")
@@ -462,19 +414,6 @@ class TestW3CSVG:
             except TypeError:
                 print("Svglib: Consider upgrading reportlab to version >= 3.3.26!")
                 raise
-
-    @pytest.mark.skipif(not found_uniconv(), reason="needs uniconv")
-    def test_convert_pdf_uniconv(self):
-        "Test converting W3C SVG files to PDF using uniconverter."
-
-        paths = glob.glob(f"{self.folder_path}/svg/*")
-        paths = [p for p in paths if splitext(p.lower())[1] in [".svg", ".svgz"]]
-        for path in paths:
-            out = splitext(path)[0] + "-uniconv.pdf"
-            cmd = f"uniconv '{path}' '{out}'"
-            os.popen(cmd).read()
-            if exists(out) and getsize(out) == 0:
-                os.remove(out)
 
 
 class TestOtherFiles:


### PR DESCRIPTION
## Summary

Removes the four `uniconv` sample tests and all related traces. They tested nothing and depended on an abandoned Python 2 tool.

## Why

Each `test_*_uniconv` method only did this:

```python
@pytest.mark.skipif(not found_uniconv(), reason="needs uniconv")
def test_convert_pdf_uniconv(self):
    for path in glob.glob(...svg...):
        out = splitext(path)[0] + "-uniconv.pdf"
        os.popen(f"uniconv '{path}' '{out}'").read()   # shell out
        if exists(out) and getsize(out) == 0:
            os.remove(out)                              # delete empties
```

- **No assertions.** They shelled out to `uniconv` to produce `-uniconv.pdf` files and deleted the empty ones. Those files were only ever touched again by `cleanup()` (deleted) — never compared to svglib's output. So they verified nothing, even with the tool installed.
- **Defunct dependency.** `uniconv` is [UniConvertor](http://sourceforge.net/projects/uniconvertor) (sK1), a Python 2 project abandoned for over a decade; it doesn't run in a modern Python 3 / `uv` environment. `found_uniconv()` (`which uniconv`) always returns false, so all four were **permanently skipped**. The old `tests/README.rst` even noted it "was not used for years."

## What

- Delete the four `test_*_uniconv` methods, the `found_uniconv()` helper, the `-uniconv.pdf` glob in `cleanup()`, the now-unused `getsize` import, and the stale module-docstring / `README.rst` references.

## Impact

- **No coverage lost** — the svglib sample-conversion tests (`test_convert_pdf`, `test_convert_pdf_png`) remain and are what actually exercise the library.
- Skips drop from **6 → 2** (the remaining two are legitimate `times.ttf` font-availability skips).
- `uv run pytest` → **160 passed, 2 skipped**; ruff + mypy clean.