### PR TITLE
Replace deprecated locale.getdefaultlocale() (removed in Python 3.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@
   private, so the leading underscore was misleading. The old underscore-
   prefixed names remain as deprecated aliases and will be **removed in 2.1.0**.
 
+### Fixed
+
+- Replaced `locale.getdefaultlocale()` (used for `<switch>` `systemLanguage`
+  matching) with a small environment-variable lookup. `getdefaultlocale()` is
+  deprecated and is **removed in Python 3.15**; the replacement keeps the same
+  behaviour, emits no deprecation warning on 3.12–3.14, and adds unit tests for
+  the language-matching path.
+
 ### Type safety and internal quality (no behavior change)
 
 - Completed static type annotations for `svglib.py`; the package now passes

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -22,7 +22,6 @@ import base64
 import copy
 import gzip
 import itertools
-import locale
 import logging
 import os
 import pathlib
@@ -968,6 +967,26 @@ def _find_clip_shape(item: Any) -> Optional[Any]:
     return None
 
 
+def _default_language() -> str:
+    """Return the user's preferred language from the environment.
+
+    Reads the standard locale environment variables and returns a language code
+    such as ``en_US`` (or an empty string if none is set). This replaces
+    ``locale.getdefaultlocale()``, which is deprecated and removed in Python
+    3.15; unlike ``locale.getlocale()`` it reflects the environment without
+    requiring a global ``setlocale()`` call.
+    """
+    for var in ("LC_ALL", "LC_CTYPE", "LANG", "LANGUAGE"):
+        value = os.environ.get(var, "")
+        if not value or value in ("C", "POSIX"):
+            continue
+        # LANGUAGE may hold a colon-separated priority list; take the first.
+        value = value.split(":")[0]
+        # Drop the encoding (".UTF-8") and modifier ("@euro") suffixes.
+        return value.split(".")[0].split("@")[0]
+    return ""
+
+
 class LinearGradientShape(DirectDraw):
     """Fills a clipped region with a linear gradient via PDF shading."""
 
@@ -1776,7 +1795,7 @@ class SvgRenderer:
         requiredExtensions, and systemLanguage conditions are all satisfied
         is rendered; remaining children are skipped.
         """
-        sys_lang = locale.getdefaultlocale()[0] or ""
+        sys_lang = _default_language()
         sys_lang_prefix = sys_lang.split("_")[0]
 
         for child in node:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1349,6 +1349,47 @@ class TestSwitchNode:
         assert len(rects) == 1
         assert rects[0].fillColor.hexval() == "0x0000ff"
 
+    def test_switch_matches_system_language(self, monkeypatch):
+        """<switch> renders the first child whose systemLanguage matches the locale."""
+        for var in ("LC_ALL", "LC_CTYPE", "LANGUAGE"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("LANG", "de_DE.UTF-8")
+        drawing = drawing_from_svg(
+            """
+            <?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+                <switch>
+                    <rect systemLanguage="fr" width="100" height="100" fill="red"/>
+                    <rect systemLanguage="de" width="80" height="80" fill="green"/>
+                    <rect width="50" height="50" fill="blue"/>
+                </switch>
+            </svg>
+        """
+        )
+        rects = self._find_rects(drawing)
+        assert len(rects) == 1
+        assert rects[0].fillColor.hexval() == "0x008000"  # "de" matches "de_DE"
+
+    def test_switch_skips_nonmatching_system_language(self, monkeypatch):
+        """<switch> skips a non-matching systemLanguage and renders the fallback."""
+        for var in ("LC_ALL", "LC_CTYPE", "LANGUAGE"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("LANG", "en_US.UTF-8")
+        drawing = drawing_from_svg(
+            """
+            <?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+                <switch>
+                    <rect systemLanguage="fr" width="100" height="100" fill="red"/>
+                    <rect width="50" height="50" fill="blue"/>
+                </switch>
+            </svg>
+        """
+        )
+        rects = self._find_rects(drawing)
+        assert len(rects) == 1
+        assert rects[0].fillColor.hexval() == "0x0000ff"  # "fr" skipped, fallback used
+
 
 class TestSymbolNode:
     def test_symbol_unused(self):


### PR DESCRIPTION
## Summary

Makes the `<switch>` `systemLanguage` handling work across **all supported Python versions, including the upcoming 3.15**, by removing a deprecated stdlib call.

## Problem

`renderSwitch` used `locale.getdefaultlocale()[0]` to read the user's preferred language. That function is:
- **deprecated** (emits a `DeprecationWarning` on Python 3.12–3.14), and
- **removed entirely in Python 3.15**.

Its documented replacement `locale.getlocale()` reflects the *process* locale (empty unless a global `locale.setlocale()` has been called) rather than the environment — not equivalent, and `setlocale()` has global side effects a library shouldn't cause.

## Fix

- Added a side-effect-free `_default_language()` helper that reads `LC_ALL` / `LC_CTYPE` / `LANG` / `LANGUAGE` directly (mirroring what `getdefaultlocale()` did internally), handling encoding/modifier suffixes and `LANGUAGE` colon-lists, returning `""` for `C`/`POSIX`/unset.
- Replaced the call site and removed the now-unused `import locale`.
- **Added two unit tests** for the `systemLanguage` matching path, which previously had no coverage.

## Verification

- Behaviour matches `getdefaultlocale` for the relevant cases (verified: `en_US.UTF-8` → `en_US`, `de_DE@euro` → `de_DE`, `fr_FR:en_US` → `fr_FR`, `C`/unset → `""`).
- On **Python 3.14** the `<switch>` tests pass under `-W error::DeprecationWarning` (no warning is raised anymore).
- `mypy --strict` = 0, config mypy = 0, ruff clean, `pytest` → 162 passed / 2 skipped.