### PR TITLE
Don't truncate embedded <image> geometry to whole points (#490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@
 
 ### Fixed
 
+- Embedded `<image>` geometry is no longer truncated to whole points. The
+  `x`, `y`, `width`, and `height` of an SVG `<image>` were each passed through
+  `int()`, so a raster placed at fractional coordinates landed up to ~1pt away
+  from a vector element with identical coordinates. Because width/height were
+  truncated too, the error grew across the image rather than being a constant
+  shift (issue #490).
 - Replaced `locale.getdefaultlocale()` (used for `<switch>` `systemLanguage`
   matching) with a small environment-variable lookup. `getdefaultlocale()` is
   deprecated and is **removed in Python 3.15**; the replacement keeps the same

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -2371,7 +2371,7 @@ class Svg2RlgShapeConverter(SvgShapeConverter):
                     width = image_width
                     height = image_height
 
-        image = Image(int(x), int(y + height), int(width), int(height), image)
+        image = Image(x, y + height, width, height, image)
 
         group = Group(image)
         group.translate(0, (y + height) * 2)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1826,6 +1826,40 @@ class TestEmbedded:
         image_group = drawing.contents[0].contents[0]
         assert image_group.transform == (0.5, 0.0, 0.0, -0.5, 0.0, 100.0)
 
+    def test_image_fractional_geometry_not_truncated(self):
+        """Fractional <image> geometry must be preserved, not truncated to ints.
+
+        A raster placed at fractional coordinates should land at the same
+        position as a vector element with identical coordinates. Truncating
+        x/y/width/height to whole points offset the raster by up to ~1pt and,
+        because width/height were truncated too, the error grew across the
+        image rather than being a constant shift (see issue #490).
+        """
+        drawing = drawing_from_svg(
+            """
+            <?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 width="100" height="100" version="1.1">
+
+                <image x="10.7" y="20.7" width="50.7" height="50.7"
+                    xlink:href="data:image/png;base64,iVBORw0KGgoAAAANS
+                UhEUgAAAAUAAAAFCAYAAACNbyblAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAAGXRFWHRTb2Z0
+                d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAABVJREFUCJlj/M/A8J8BDTChC1BBEADOqQI
+                IH8PejQAAAABJRU5ErkJggg=="/>
+            </svg>
+        """
+        )
+
+        image = self.find_image_in_drawing(drawing)
+
+        assert image is not None
+        assert image.x == 10.7
+        assert image.width == 50.7
+        assert image.height == 50.7
+        # y is stored flipped as y + height; the enclosing group re-flips it.
+        assert image.y == pytest.approx(20.7 + 50.7)
+
 
 class TestGradients:
     """Tests for SVG linearGradient and radialGradient support."""


### PR DESCRIPTION
Fixes #490.

`Svg2RlgShapeConverter.convertImage` passed `x`, `y`, `width`, and `height`
through `int()` when building the ReportLab `Image`, while flipping the
enclosing group by the **un-truncated** value:

```python
image = Image(int(x), int(y + height), int(width), int(height), image)
group = Group(image)
group.translate(0, (y + height) * 2)   # un-truncated
group.scale(1, -1)
```

So a raster embedded at fractional coordinates landed up to ~1pt away from a
vector element (path, rect, line) given the same coordinates. Because
`width`/`height` were truncated too, the error was a small scale + shift rather
than a constant offset — it grew toward the far edge, so it couldn't be
cancelled by shifting the overlay.

As discussed in the issue, there's no apparent reason for the casts (they date
back to the original embedded-image support in #93, 2017), and dropping them
places the raster at full precision.

## Change

- Remove the four `int()` casts in `convertImage`.
- Add `TestEmbedded.test_image_fractional_geometry_not_truncated`, which places
  an `<image>` at fractional coordinates and asserts the resulting `Image`
  keeps `x`/`width`/`height` un-truncated (and `y == y + height`, matching the
  group re-flip). It fails on the old code (`10 == 10.7`) and passes now.

## Verification

`pytest tests/test_basic.py` → 89 passed, 1 skipped. The existing
`test_image_with_transform` and the `test_image_size_fallback_*` tests are
unaffected (their geometry is integral).