### PR TITLE
fix: respect display:none set via the style attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 ### Fixed
 
+- `display: none` set through a `style` attribute is now respected. Only the
+  `display` presentation attribute was read, so `<g style="display:none">` and
+  `<rect style="display:none"/>` were still rendered (issue #401).
+
 - Embedded `<image>` geometry is no longer truncated to whole points. The
   `x`, `y`, `width`, and `height` of an SVG `<image>` were each passed through
   `int()`, so a raster placed at fractional coordinates landed up to ~1pt away

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -1192,7 +1192,7 @@ class SvgRenderer:
             item = self.renderA(node)
             parent.add(item)
         elif name == "g":
-            display = node.getAttribute("display")
+            display = self.get_display(node)
             item = self.renderG(node, clipping=clipping)
             if display != "none":
                 parent.add(item)
@@ -1238,7 +1238,7 @@ class SvgRenderer:
                     node._resolved_target = target
 
             item = self.shape_converter.convertShape(name, node, clipping)
-            display = node.getAttribute("display")
+            display = self.get_display(node)
             if item and display != "none":
                 fill_val = self.attrConverter.findAttr(node, "fill")
                 m = _GRADIENT_URL_RE.fullmatch(fill_val.strip()) if fill_val else None
@@ -1438,6 +1438,27 @@ class SvgRenderer:
         group.add(grad_shape)
         group.add(item)
         return group
+
+    def get_display(self, node: NodeTracker) -> str:
+        """Return the effective 'display' value of a node.
+
+        The value may be set either as a presentation attribute
+        (``display="none"``) or inside the ``style`` attribute
+        (``style="display:none"``); both forms are equivalent in SVG.
+
+        Args:
+            node: The NodeTracker object for the SVG node.
+
+        Returns:
+            The display value, or an empty string if it is not set.
+        """
+        display = node.getAttribute("display")
+        style = node.getAttribute("style")
+        if style:
+            display = self.attrConverter.parseMultiAttributes(style).get(
+                "display", display
+            )
+        return display.strip()
 
     def get_clippath(self, node: NodeTracker) -> Optional[Any]:
         """Get the clipping path object referenced by a node's 'clip-path' attribute.

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -923,6 +923,31 @@ class TestGroupNode:
         assert pth_gr.svgid == "path819"
         assert isinstance(pth_gr, Group)
 
+    def test_display_none_in_style_attribute(self):
+        """display:none set through the style attribute hides the node."""
+        drawing = drawing_from_svg(
+            """
+            <?xml version="1.0"?>
+            <svg width="100" height="100">
+                <rect x="5" y="5" width="10" height="10"/>
+                <rect x="5" y="25" width="10" height="10" style="display:none"/>
+                <g style="display:none">
+                    <rect x="5" y="45" width="10" height="10"/>
+                </g>
+            </svg>
+        """
+        )
+        rects = []
+
+        def collect(node):
+            for child in getattr(node, "contents", []):
+                if isinstance(child, Rect):
+                    rects.append(child)
+                collect(child)
+
+        collect(drawing)
+        assert [rect.y for rect in rects] == [5]
+
     def test_svg_layers_have_label(self):
         drawing = drawing_from_svg(
             """


### PR DESCRIPTION
Closes #401

`display` was only read as a presentation attribute, so `<g style="display:none">` and shapes carrying `style="display:none"` were still rendered while the `display="none"` form was correctly hidden. Both spellings are equivalent in SVG.

Added `SvgRenderer.get_display()`, which prefers a `display` declaration from the `style` attribute and falls back to the attribute, and used it in the group and shape branches. New test in `tests/test_basic.py` fails without the change and passes with it.

(`visibility:hidden` is a separate, still-unhandled part of that issue and is deliberately out of scope here.)
