### PR TITLE
Fix _GRADIENT_URL_RE for single and double quotes.

### DIFF
--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -867,7 +867,8 @@ class ExternalSVG:
 
 _BEZIER_KAPPA = 0.5523  # cubic bezier constant for circle approximation
 
-_GRADIENT_URL_RE = re.compile(r"url\(#([^)]+)\)")
+# Match values: url(#name), url('#name'), url("#name"), url( "#name" )
+_GRADIENT_URL_RE = re.compile(r"""url\(\s*(['"]?)#([^'")\s]+)\1\s*\)""")
 
 
 def _shape_to_pdf_path(canvas: Any, shape: Any) -> Any:
@@ -1243,7 +1244,7 @@ class SvgRenderer:
                 fill_val = self.attrConverter.findAttr(node, "fill")
                 m = _GRADIENT_URL_RE.fullmatch(fill_val.strip()) if fill_val else None
                 if m:
-                    grad_id = m.group(1)
+                    grad_id = m.group(2)
                     grad_def = self._resolve_gradient(grad_id)
                     if grad_def is not None:
                         item = self._apply_gradient_fill(item, grad_def)

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -868,7 +868,7 @@ class ExternalSVG:
 _BEZIER_KAPPA = 0.5523  # cubic bezier constant for circle approximation
 
 # Match values: url(#name), url('#name'), url("#name"), url( "#name" )
-_GRADIENT_URL_RE = re.compile(r"""url\(\s*(['"]?)#([^'")\s]+)\1\s*\)""")
+_GRADIENT_URL_RE = re.compile(r"""url\(\s*(['"]?)#([^'"]+?)\1\s*\)""")
 
 
 def _shape_to_pdf_path(canvas: Any, shape: Any) -> Any:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -2066,12 +2066,13 @@ class TestGradients:
         stop0_color = grad["stops"][0][1]
         assert stop0_color.alpha == pytest.approx(0.5)
 
-    def _get_svg(self, fill):
+    def _get_svg(self, fill, name):
         return f"""
             <?xml version="1.0"?>
             <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
                 <defs>
-                    <linearGradient id="grad1" x1="0" y1="0" x2="1" y2="0" gradientUnits="objectBoundingBox">
+                    <linearGradient id="{name}" x1="0" y1="0" x2="1" y2="0"
+                            gradientUnits="objectBoundingBox">
                         <stop offset="0" stop-color="red" stop-opacity="1"/>
                         <stop offset="1" stop-color="blue" stop-opacity="1"/>
                     </linearGradient>
@@ -2079,9 +2080,9 @@ class TestGradients:
                 <rect x="10" y="10" width="80" height="80" fill={fill}/>
             </svg>"""
 
-    def _process_test_fill_url(self, name):
+    def _process_test_fill_url(self, fill, name="grad1"):
         """Process test fill url."""
-        drawing = drawing_from_svg(self._get_svg(name))
+        drawing = drawing_from_svg(self._get_svg(fill, name))
 
         assert len(drawing.contents) == 1
         group = drawing.contents[0]
@@ -2096,7 +2097,10 @@ class TestGradients:
         assert isinstance(rect, Rect)
 
         assert gradient._positions == [0.0, 1.0]
-        assert gradient._rl_colors == [colors.Color(1,0,0,1), colors.Color(0,0,1,1)]
+        assert gradient._rl_colors == [
+            colors.Color(1, 0, 0, 1),
+            colors.Color(0, 0, 1, 1),
+        ]
 
     def test_fill_url_witout_quotes(self):
         """Fill url witout quotes."""
@@ -2104,7 +2108,19 @@ class TestGradients:
 
     def test_fill_url_witout_quotes_space(self):
         """Fill url witout quotes."""
+        self._process_test_fill_url('"url(#grad 1)"', "grad 1")
+
+    def test_fill_url_witout_quotes_parenthesis(self):
+        """Fill url witout quotes."""
+        self._process_test_fill_url('"url(#grad)1)"', "grad)1")
+
+    def test_fill_url_witout_quotes_strip(self):
+        """Fill url witout quotes."""
         self._process_test_fill_url('"url( #grad1 )"')
+
+    def test_fill_url_witout_quotes_strip_space(self):
+        """Fill url witout quotes."""
+        self._process_test_fill_url('"url( #grad 1 )"', "grad 1")
 
     def test_fill_url_enclosed_single_quotes(self):
         """Fill url enclosed single quotes."""
@@ -2112,12 +2128,32 @@ class TestGradients:
 
     def test_fill_url_enclosed_single_quotes_space(self):
         """Fill url enclosed single quotes."""
+        self._process_test_fill_url('''"url('#grad 1')"''', "grad 1")
+
+    def test_fill_url_enclosed_single_quotes_strip(self):
+        """Fill url enclosed single quotes."""
         self._process_test_fill_url('''"url( '#grad1' )"''')
+
+    def test_fill_url_enclosed_single_quotes_strip_space(self):
+        """Fill url enclosed single quotes."""
+        self._process_test_fill_url('''"url( '#grad 1' )"''', "grad 1")
 
     def test_fill_url_enclosed_double_quotes(self):
         """Fill url enclosed double quotes."""
         self._process_test_fill_url("""'url("#grad1")'""")
 
-    def test_fill_url_enclosed_double_quotes_space(self):
+    def test_fill_url_enclosed_double_quotes_parenthesis(self):
+        """Fill url enclosed double quotes."""
+        self._process_test_fill_url("""'url("#grad())1")'""", "grad())1")
+
+    def test_fill_url_enclosed_double_quotes_strip(self):
         """Fill url enclosed double quotes."""
         self._process_test_fill_url("""'url( "#grad1" )'""")
+
+    def test_fill_url_enclosed_double_quotes_strip_space(self):
+        """Fill url enclosed double quotes."""
+        self._process_test_fill_url("""'url( "#grad 1" )'""", "grad 1")
+
+    def test_fill_url_enclosed_double_quotes_strip_parenthesis(self):
+        """Fill url enclosed double quotes."""
+        self._process_test_fill_url("""'url( "#grad)1" )'""", "grad)1")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -33,7 +33,7 @@ from reportlab.lib.units import cm, inch
 from reportlab.pdfgen.canvas import FILL_EVEN_ODD, FILL_NON_ZERO
 
 from svglib import svglib, utils
-from svglib.svglib import ClippingPath
+from svglib.svglib import ClippingPath, LinearGradientShape
 from tests.test_samples import has_renderpm_backend
 from tests.utils import (
     drawing_from_svg,
@@ -2065,3 +2065,59 @@ class TestGradients:
         assert grad is not None
         stop0_color = grad["stops"][0][1]
         assert stop0_color.alpha == pytest.approx(0.5)
+
+    def _get_svg(self, fill):
+        return f"""
+            <?xml version="1.0"?>
+            <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+                <defs>
+                    <linearGradient id="grad1" x1="0" y1="0" x2="1" y2="0" gradientUnits="objectBoundingBox">
+                        <stop offset="0" stop-color="red" stop-opacity="1"/>
+                        <stop offset="1" stop-color="blue" stop-opacity="1"/>
+                    </linearGradient>
+                </defs>
+                <rect x="10" y="10" width="80" height="80" fill={fill}/>
+            </svg>"""
+
+    def _process_test_fill_url(self, name):
+        """Process test fill url."""
+        drawing = drawing_from_svg(self._get_svg(name))
+
+        assert len(drawing.contents) == 1
+        group = drawing.contents[0]
+        assert isinstance(group, Group)
+
+        assert len(group.contents) == 1
+        group2 = group.contents[0]
+        assert isinstance(group2, Group)
+
+        gradient, rect = group2.contents
+        assert isinstance(gradient, LinearGradientShape)
+        assert isinstance(rect, Rect)
+
+        assert gradient._positions == [0.0, 1.0]
+        assert gradient._rl_colors == [colors.Color(1,0,0,1), colors.Color(0,0,1,1)]
+
+    def test_fill_url_witout_quotes(self):
+        """Fill url witout quotes."""
+        self._process_test_fill_url('"url(#grad1)"')
+
+    def test_fill_url_witout_quotes_space(self):
+        """Fill url witout quotes."""
+        self._process_test_fill_url('"url( #grad1 )"')
+
+    def test_fill_url_enclosed_single_quotes(self):
+        """Fill url enclosed single quotes."""
+        self._process_test_fill_url('''"url('#grad1')"''')
+
+    def test_fill_url_enclosed_single_quotes_space(self):
+        """Fill url enclosed single quotes."""
+        self._process_test_fill_url('''"url( '#grad1' )"''')
+
+    def test_fill_url_enclosed_double_quotes(self):
+        """Fill url enclosed double quotes."""
+        self._process_test_fill_url("""'url("#grad1")'""")
+
+    def test_fill_url_enclosed_double_quotes_space(self):
+        """Fill url enclosed double quotes."""
+        self._process_test_fill_url("""'url( "#grad1" )'""")


### PR DESCRIPTION
Fix `_GRADIENT_URL_RE` for all types of url value:

1. without quotation marks `url(#name)`
2. enclosed in single quotes `url('#name')`
3. enclosed in quotation marks `url("#name")`
4. spaces before and after the value `url( #name )`, `url( '#name' )`, `url( "#name" )`
