### PR TITLE
Fix AttributeError: 'SVGCanvas' object has no attribute 'beginPath'.

### DIFF
--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -45,6 +45,7 @@ from typing import (
 )
 
 from PIL import Image as PILImage
+from reportlab.graphics.renderSVG import SVGCanvas
 from reportlab.graphics.shapes import (
     _CLOSEPATH,
     Circle,
@@ -877,6 +878,11 @@ def _shape_to_pdf_path(canvas: Any, shape: Any) -> Any:
     Handles Path, Rect, Circle, Ellipse, and Polygon; falls back to the
     shape's bounding box for other types.
     """
+    if isinstance(canvas, SVGCanvas) and not hasattr(canvas, "beginPath"):
+        # SVGCanvas doesn't have function beginPath. It is used here:
+        # easy-thumbnails[svg]==2.10.1
+        # https://github.com/SmileyChris/easy-thumbnails/blob/2.10.1/easy_thumbnails/VIL/Image.py#L21
+        return None
     pdfPath = canvas.beginPath()
     if isinstance(shape, Path):
         draw_funcs = (pdfPath.moveTo, pdfPath.lineTo, pdfPath.curveTo, pdfPath.close)
@@ -1014,18 +1020,18 @@ class LinearGradientShape(DirectDraw):
         """Paint the linear gradient into the clipped region on the PDF canvas."""
         canvas = renderer._canvas
         canvas.saveState()
-        pdfPath = _shape_to_pdf_path(canvas, self._clip_shape)
-        canvas.clipPath(pdfPath, fill=1, stroke=0)
-        canvas.linearGradient(
-            self._x0,
-            self._y0,
-            self._x1,
-            self._y1,
-            self._rl_colors,
-            self._positions,
-            self._extend,
-        )
-        canvas.restoreState()
+        if pdfPath := _shape_to_pdf_path(canvas, self._clip_shape):
+            canvas.clipPath(pdfPath, fill=1, stroke=0)
+            canvas.linearGradient(
+                self._x0,
+                self._y0,
+                self._x1,
+                self._y1,
+                self._rl_colors,
+                self._positions,
+                self._extend,
+            )
+            canvas.restoreState()
 
     def getBounds(self) -> Tuple[float, float, float, float]:
         """Return the bounds of the clipped region this gradient fills."""
@@ -1056,17 +1062,17 @@ class RadialGradientShape(DirectDraw):
         """Paint the radial gradient into the clipped region on the PDF canvas."""
         canvas = renderer._canvas
         canvas.saveState()
-        pdfPath = _shape_to_pdf_path(canvas, self._clip_shape)
-        canvas.clipPath(pdfPath, fill=1, stroke=0)
-        canvas.radialGradient(
-            self._cx,
-            self._cy,
-            self._r,
-            self._rl_colors,
-            self._positions,
-            self._extend,
-        )
-        canvas.restoreState()
+        if pdfPath := _shape_to_pdf_path(canvas, self._clip_shape):
+            canvas.clipPath(pdfPath, fill=1, stroke=0)
+            canvas.radialGradient(
+                self._cx,
+                self._cy,
+                self._r,
+                self._rl_colors,
+                self._positions,
+                self._extend,
+            )
+            canvas.restoreState()
 
     def getBounds(self) -> Tuple[float, float, float, float]:
         """Return the bounds of the clipped region this gradient fills."""

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -23,7 +23,7 @@ from typing import Any
 from urllib.parse import quote, unquote, urlparse
 
 import pytest
-from reportlab.graphics import renderPDF, renderPM
+from reportlab.graphics import renderPDF, renderPM, renderSVG
 from reportlab.graphics.shapes import Group, Rect
 
 from svglib import svglib
@@ -132,6 +132,31 @@ class TestSVGSamples:
             # save as PDF
             base = splitext(path)[0] + "-svglib.pdf"
             renderPDF.drawToFile(drawing, base, showBoundary=0)
+
+
+class TestSVGCanvas:
+    "Test SVGCanvas."
+
+    def test_canvas(self):
+        "Test SVGCanvas for _shape_to_pdf_path."
+        paths = [
+            f"{TEST_ROOT}/samples/misc/{filename}"
+            for filename in (
+                "firefox-logo.svg",
+                "gradient_showcase.svg",
+                "Python_logo_and_wordmark.svg",
+            )
+        ]
+        for i, path in enumerate(paths):
+            print(f"working on [{i}] {path}")
+            drawing = svglib.svg2rlg(path)
+            canvas = renderSVG.SVGCanvas()
+            renderSVG.draw(drawing, canvas)
+            buffer = io.StringIO()
+            canvas.save(buffer)
+            content = buffer.getvalue()
+            assert "<title>...</title>" in content
+            assert "<desc>...</desc>" in content
 
 
 class TestWikipediaSymbols:


### PR DESCRIPTION
Class `renderSVG.SVGCanvas` does not have a `beginPath` function, which will throw an `AttributeError` exception. It is used in `easy-thumbnails[svg]==2.10.1`.

https://github.com/SmileyChris/easy-thumbnails/blob/2.10.1/easy_thumbnails/VIL/Image.py#L21