### PR TITLE
fix: respect the visibility property on shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 ### Fixed
 
+- The `visibility` property is now respected on shapes. Elements with
+  `visibility="hidden"` (or `collapse`), set directly or inherited from an
+  ancestor, were still rendered (issue #359).
+
 - `display: none` set through a `style` attribute is now respected. Only the
   `display` presentation attribute was read, so `<g style="display:none">` and
   `<rect style="display:none"/>` were still rendered (issue #401).

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -1295,7 +1295,8 @@ class SvgRenderer:
 
             item = self.shape_converter.convertShape(name, node, clipping)
             display = self.get_display(node)
-            if item and display != "none":
+            visibility = self.attrConverter.findAttr(node, "visibility")
+            if item and display != "none" and visibility not in ("hidden", "collapse"):
                 fill_val = self.attrConverter.findAttr(node, "fill")
                 m = _GRADIENT_URL_RE.fullmatch(fill_val.strip()) if fill_val else None
                 if m:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -965,6 +965,33 @@ class TestGroupNode:
         collect(drawing)
         assert [rect.y for rect in rects] == [5]
 
+    def test_visibility_hidden(self):
+        """visibility hidden/collapse hides the node, and is inheritable."""
+        drawing = drawing_from_svg(
+            """
+            <?xml version="1.0"?>
+            <svg width="100" height="100">
+                <rect x="5" y="5" width="10" height="10"/>
+                <rect x="5" y="25" width="10" height="10" visibility="hidden"/>
+                <rect x="5" y="45" width="10" height="10" style="visibility:collapse"/>
+                <g visibility="hidden">
+                    <rect x="5" y="65" width="10" height="10"/>
+                    <rect x="5" y="85" width="10" height="10" visibility="visible"/>
+                </g>
+            </svg>
+        """
+        )
+        rects = []
+
+        def collect(node):
+            for child in getattr(node, "contents", []):
+                if isinstance(child, Rect):
+                    rects.append(child)
+                collect(child)
+
+        collect(drawing)
+        assert [rect.y for rect in rects] == [5, 85]
+
     def test_svg_layers_have_label(self):
         drawing = drawing_from_svg(
             """


### PR DESCRIPTION
Closes #359

`renderNode` only consulted `display`, so a shape with `visibility="hidden"` was still rendered. The value is now resolved with `findAttr`, which reads the `style` attribute and walks ancestors, so inheritance from a group and a `visibility="visible"` override on a child both behave correctly; `collapse` is treated as hidden too.

Regression test added in `tests/test_basic.py` next to the `display:none` test — it fails without the one-line change and passes with it.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
