### PR TITLE
Prepare 2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.1.0 (2026-08-01)
 
 ### Added
 
@@ -20,8 +20,12 @@
 - Renamed the gradient shape classes `_LinearGradientShape` and
   `_RadialGradientShape` to `LinearGradientShape` and `RadialGradientShape`.
   They appear in the rendered `Drawing` tree and were never meant to be
-  private, so the leading underscore was misleading. The old underscore-
-  prefixed names remain as deprecated aliases and will be **removed in 2.1.0**.
+  private, so the leading underscore was misleading.
+
+### Removed
+
+- Removed the deprecated `_LinearGradientShape` and `_RadialGradientShape`
+  aliases. Use `LinearGradientShape` and `RadialGradientShape` instead.
 
 ### Fixed
 
@@ -53,6 +57,15 @@
   the language-matching path.
 - Clipping paths now support the `clip-rule` attribute instead of incorrectly
   using `fill-rule` (issue #485).
+- `fill="url(...)"` and gradient `xlink:href` values are now matched correctly
+  when the referenced id is quoted (`url('#name')`, `url("#name")`) or
+  contains a right parenthesis; the previous regex rejected or truncated
+  these forms.
+- Rendering to `reportlab.graphics.renderSVG.SVGCanvas` (as used by
+  `easy-thumbnails[svg]`) no longer raises
+  `AttributeError: 'SVGCanvas' object has no attribute 'beginPath'` when
+  drawing a clipped gradient; that canvas doesn't implement `beginPath()`,
+  so the gradient's clip path is now skipped on it instead of erroring.
 
 ### Type safety and internal quality (no behavior change)
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,8 @@ This is the (preliminary) list of contributors in no particular order:
 - Tom Turner
 - Danny Elfanbaum
 - Blayze Wilhelm
+- Sanjay Santhanam
+- Zdeněk Böhm
 
 If you are not listed here, but feel like you should be, please contact
 the maintainers. If you create a pull request, feel free to add your

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svglib"
-version = "2.0.2"
+version = "2.1.0"
 description = "A pure-Python library for reading and converting SVG"
 readme = "README.md"
 authors = [{ name = "Dinu Gherman" }]

--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -1134,13 +1134,6 @@ class RadialGradientShape(DirectDraw):
         return cast(Tuple[float, float, float, float], self._clip_shape.getBounds())
 
 
-# Deprecated aliases for the underscore-prefixed names these classes had before
-# they were made public. They were never meant to be private, but the leading
-# underscore wrongly signalled so. Scheduled for removal in 2.1.0.
-_LinearGradientShape = LinearGradientShape
-_RadialGradientShape = RadialGradientShape
-
-
 # ## the main meat ###
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -961,7 +961,7 @@ wheels = [
 
 [[package]]
 name = "svglib"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cssselect2" },


### PR DESCRIPTION
- Add changelog entries for #497 (gradient url regex) and #498 (SVGCanvas.beginPath AttributeError), missed at merge time.
- Add Sanjay Santhanam and Zdeněk Böhm to CONTRIBUTORS.md.
- Retitle Unreleased to 2.1.0 and bump pyproject.toml/uv.lock.
- Remove the deprecated _LinearGradientShape/_RadialGradientShape aliases, as scheduled for this release.