### PR TITLE
Prepare 2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.2.0 (2026-08-14)
 
 ### Tooling and housekeeping
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ This is the (preliminary) list of contributors in no particular order:
 - Blayze Wilhelm
 - Sanjay Santhanam
 - Zdeněk Böhm
+- Nicolas Zunhammer
 
 If you are not listed here, but feel like you should be, please contact
 the maintainers. If you create a pull request, feel free to add your

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svglib"
-version = "2.1.0"
+version = "2.2.0"
 description = "A pure-Python library for reading and converting SVG"
 readme = "README.md"
 authors = [{ name = "Dinu Gherman" }]

--- a/uv.lock
+++ b/uv.lock
@@ -961,7 +961,7 @@ wheels = [
 
 [[package]]
 name = "svglib"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cssselect2" },


### PR DESCRIPTION
## Summary

- Add Nicolas Zunhammer to CONTRIBUTORS.md (font-size `PX_TO_PT` double-conversion fix, #503).
- Retitle `## Unreleased` to `## 2.2.0` in CHANGELOG.md.
- Bump `pyproject.toml`/`uv.lock` version 2.1.0 → 2.2.0.

## Test plan

- [x] `uv run pytest -q` — 190 passed, 2 skipped, 1 xfailed, no warnings
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run mypy src tests` — clean