### PR TITLE
Ignore a malformed viewBox instead of raising TypeError

### DIFF
--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -1757,8 +1757,14 @@ class SvgRenderer:
         if view_box:
             # viewBox defines a unitless user-coordinate space (SVG spec §8.1).
             # Parse as raw floats — never apply unit conversion here.
-            values = [float(v) for v in view_box.replace(",", " ").split()]
-            return Box(*values)
+            try:
+                values = [float(v) for v in view_box.replace(",", " ").split()]
+            except ValueError:
+                values = []
+            if len(values) == 4:
+                return Box(*values)
+            # A viewBox that is not four numbers is invalid and ignored per the
+            # SVG spec; fall through to the width/height fallback below.
         if default_box:
             width, height = map(svg_node.getAttribute, ("width", "height"))
             width, height = map(self.attrConverter.convertLength, (width, height))  # type: ignore

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -112,6 +112,18 @@ class TestSvg2rlgInput:
             os.unlink(file_path)
 
 
+def test_malformed_viewbox_is_ignored():
+    # A viewBox that is not four numbers used to raise TypeError from
+    # Box(*values); per the SVG spec an invalid viewBox is ignored, falling
+    # back to width/height, instead of crashing.
+    for view_box in ("0 0 100", "0 0 100 100 200", "0 0 abc 100", "0,0,100"):
+        drawing = drawing_from_svg(
+            '<svg xmlns="http://www.w3.org/2000/svg" width="50" height="40" '
+            'viewBox="%s"><rect x="1" y="1" width="5" height="5"/></svg>' % view_box
+        )
+        assert drawing is not None
+
+
 class TestPaths:
     """Testing path-related code."""
 


### PR DESCRIPTION
An SVG with a viewBox that isn't four numbers crashes `svg2rlg`:

```python
import io
from svglib.svglib import svg2rlg
svg2rlg(io.StringIO('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100"><rect width="5" height="5"/></svg>'))
# TypeError: Box.__new__() missing 1 required positional argument: 'height'
```

`get_box` does `values = [float(v) for v in view_box.split()]` then `return Box(*values)` without checking the count, so a viewBox with the wrong number of values raises `TypeError` (and a non-numeric one raises `ValueError`). Per the SVG spec an invalid viewBox is ignored, so I fall through to the existing width/height fallback when it doesn't parse to exactly four numbers. Valid viewBoxes are unaffected.

Added a test; it raises TypeError on `main` and passes with the change, and the rest of test_basic.py still passes. Found it by fuzzing `svg2rlg` with mutated SVG.