### PR TITLE
Don't raise IndexError on an unbalanced transform expression

### DIFF
--- a/src/svglib/svglib.py
+++ b/src/svglib/svglib.py
@@ -480,7 +480,9 @@ class AttributeConverter:
         for i, lin in enumerate(line):
             if lin in "()":
                 brackets.append(i)
-        for i in range(0, len(brackets), 2):
+        # Step in pairs and stop before a final unmatched "(" or ")" so an
+        # unbalanced transform (e.g. "scale(2") does not index past the list.
+        for i in range(0, len(brackets) - 1, 2):
             bi, bj = brackets[i], brackets[i + 1]
             subline = line[bi + 1 : bj]
             subline = subline.strip()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -649,6 +649,9 @@ class TestTransformAttrConverter:
             # Invalid/unsupported expressions return empty list
             ("scale(0.9), translate", []),
             ("ref(svg)", []),
+            # Unbalanced parentheses used to raise IndexError
+            ("scale(2", []),
+            ("rotate(45", []),
         )
         ac = svglib.Svg2RlgAttributeConverter()
         failed = _testit(ac.convertTransform, mapping)


### PR DESCRIPTION
A transform attribute with an unmatched parenthesis crashes the converter:

```python
from svglib.svglib import Svg2RlgAttributeConverter
Svg2RlgAttributeConverter().convertTransform('scale(2')
# IndexError: list index out of range
```

`convertTransform` collects the indices of all `(`/`)` characters and walks them two at a time as open/close pairs via `range(0, len(brackets), 2)`, reading `brackets[i + 1]`. An unmatched parenthesis leaves an odd number of positions, so the last iteration indexes past the list. I step to `len(brackets) - 1` so a final unmatched bracket is skipped; the transform is then reported as unparsable and ignored, matching how other invalid transforms are handled. Valid transforms are unaffected.

Extended the existing `TestTransformAttrConverter` mapping with unbalanced cases; it raises IndexError on `main` and passes with the change. Found it by fuzzing `svg2rlg` with mutated SVG.